### PR TITLE
chore(setup): add root package.json with workspace scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,22 @@
   "type": "module",
   "description": "Monorepo for vite-open-api-server plugin and playground",
   "scripts": {
-    "preinstall": "npx only-allow pnpm"
+    "preinstall": "npx only-allow pnpm",
+    "dev": "pnpm -r --parallel --filter='./packages/*' run dev",
+    "build": "pnpm -r --filter='./packages/*' run build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write .",
+    "typecheck": "tsc --noEmit",
+    "playground": "pnpm --filter petstore-app dev",
+    "clean": "pnpm -r exec rm -rf dist node_modules",
+    "changeset": "workspace changeset create",
+    "release": "workspace bump --execute --git-tag --git-push"
   },
   "engines": {
-    "node": ">=22.12.0",
-    "pnpm": ">=9.0.0"
+    "node": "^20.19.0 || >=22.12.0"
   },
   "packageManager": "pnpm@9.15.0",
   "keywords": [


### PR DESCRIPTION
- Updated engines field to support Node.js ^20.19.0 || >=22.12.0
- Added development scripts: dev, build, test, lint, format, typecheck
- Added workspace scripts: playground, clean, changeset, release
- Configured for monorepo orchestration with pnpm workspace commands

Closes: vite-open-api-server-rz1.3