### PR TITLE
feat(runner): implement mock server with Scalar and Hono integration

### DIFF
--- a/.changesets/feature-p1-05-mock-server-integration.json
+++ b/.changesets/feature-p1-05-mock-server-integration.json
@@ -1,0 +1,13 @@
+{
+  "branch": "feature/p1-05-mock-server-integration",
+  "bump": "minor",
+  "environments": [
+    "production"
+  ],
+  "packages": [
+    "@websublime/vite-plugin-open-api-server"
+  ],
+  "changes": [],
+  "created_at": "2026-01-14T11:06:15.862446Z",
+  "updated_at": "2026-01-14T11:06:15.863109Z"
+}

--- a/packages/vite-plugin-open-api-server/biome.json
+++ b/packages/vite-plugin-open-api-server/biome.json
@@ -2,5 +2,17 @@
   "extends": "//",
   "files": {
     "includes": ["**", "!node_modules", "!dist"]
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["src/runner/**/*.mts", "src/runner/**/*.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/packages/vite-plugin-open-api-server/package.json
+++ b/packages/vite-plugin-open-api-server/package.json
@@ -38,21 +38,22 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "@scalar/mock-server": "^0.8.9",
-    "chokidar": "^5.0.0",
-    "@scalar/openapi-parser": "^0.23.11",
     "@hono/node-server": "^1.19.7",
+    "@scalar/mock-server": "^0.8.9",
+    "@scalar/openapi-parser": "^0.23.11",
+    "chokidar": "^5.0.0",
+    "hono": "^4.11.4",
     "yaml": "^2.8.2"
   },
   "devDependencies": {
-    "typescript": "^5.9.3",
-    "vitest": "^4.0.16",
-    "@types/node": "^25.0.3",
     "@faker-js/faker": "^10.2.0",
-    "vite": "^7.3.1",
+    "@types/node": "^25.0.3",
     "@vue/devtools-api": "^8.0.5",
     "openapi-types": "^12.1.3",
-    "tsdown": "^0.19.0-beta.5"
+    "tsdown": "^0.19.0-beta.5",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1",
+    "vitest": "^4.0.16"
   },
   "peerDependencies": {
     "vite": "^6.0.0 || ^7.0.0"

--- a/packages/vite-plugin-open-api-server/src/runner/openapi-server-runner.mts
+++ b/packages/vite-plugin-open-api-server/src/runner/openapi-server-runner.mts
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+/**
+ * OpenAPI Mock Server Runner
+ *
+ * Standalone HTTP server that generates mock responses from OpenAPI specs.
+ * Runs as a child process, communicates with Vite plugin via IPC.
+ *
+ * ## What
+ * This module serves as the entry point for the mock server child process.
+ * It reads configuration from environment variables, loads an OpenAPI spec,
+ * creates a Scalar mock server, and starts an HTTP server using Hono.
+ *
+ * ## How
+ * 1. Parse environment variables for configuration (PORT, OPENAPI_SPEC_PATH, etc.)
+ * 2. Load and validate OpenAPI specification using the parser module
+ * 3. Create Scalar mock server instance with the parsed spec
+ * 4. Add request logging middleware (conditional on VERBOSE)
+ * 5. Start HTTP server with @hono/node-server
+ * 6. Send ready IPC message to parent process
+ * 7. Handle graceful shutdown on SIGTERM/SIGINT/IPC messages
+ *
+ * ## Why
+ * Running the mock server in a separate child process provides:
+ * - Process isolation (crashes don't affect Vite)
+ * - Independent restart capability
+ * - Clear IPC protocol for parent-child communication
+ * - Resource management and cleanup
+ *
+ * Configuration via environment variables:
+ * - PORT: HTTP server port (default: 3001)
+ * - OPENAPI_SPEC_PATH: Path to OpenAPI spec file (required)
+ * - VERBOSE: Enable verbose logging (default: false)
+ * - HANDLERS_DIR: Custom handlers directory (optional)
+ * - SEEDS_DIR: Seed data directory (optional)
+ *
+ * @module runner/openapi-server-runner
+ */
+
+import { type ServerType, serve } from '@hono/node-server';
+import { createMockServer } from '@scalar/mock-server';
+import { Hono } from 'hono';
+
+import { loadOpenApiSpec } from '../core/parser/index.js';
+import type { OpenApiServerMessage } from '../types/ipc-messages.js';
+
+/**
+ * Configuration object parsed from environment variables.
+ */
+interface RunnerConfig {
+  /** HTTP server port */
+  port: number;
+  /** Path to OpenAPI specification file */
+  specPath: string;
+  /** Enable verbose request logging */
+  verbose: boolean;
+  /** Custom handlers directory (optional) */
+  handlersDir?: string;
+  /** Seed data directory (optional) */
+  seedsDir?: string;
+}
+
+/**
+ * Reads and validates configuration from environment variables.
+ *
+ * @returns Parsed configuration object
+ * @throws {Error} If OPENAPI_SPEC_PATH is not provided
+ */
+function readConfig(): RunnerConfig {
+  const specPath = process.env.OPENAPI_SPEC_PATH;
+
+  if (!specPath) {
+    console.error('[mock-server] ERROR: OPENAPI_SPEC_PATH environment variable is required');
+    process.exit(1);
+  }
+
+  return {
+    port: Number.parseInt(process.env.PORT || '3001', 10),
+    specPath,
+    verbose: process.env.VERBOSE === 'true',
+    handlersDir: process.env.HANDLERS_DIR || undefined,
+    seedsDir: process.env.SEEDS_DIR || undefined,
+  };
+}
+
+/**
+ * Counts the total number of endpoints in an OpenAPI paths object.
+ *
+ * @param paths - The paths object from the OpenAPI spec
+ * @returns Total number of endpoint operations
+ */
+function countEndpoints(paths: Record<string, unknown> | undefined): number {
+  if (!paths) {
+    return 0;
+  }
+
+  const methods = ['get', 'post', 'put', 'patch', 'delete', 'options', 'head', 'trace'];
+  let count = 0;
+
+  for (const pathItem of Object.values(paths)) {
+    if (typeof pathItem === 'object' && pathItem !== null) {
+      for (const method of methods) {
+        if (method in pathItem) {
+          count++;
+        }
+      }
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Sends an IPC message to the parent process if available.
+ *
+ * @param message - The message to send
+ */
+function sendIpcMessage(message: OpenApiServerMessage): void {
+  if (process.send) {
+    process.send(message);
+  }
+}
+
+/**
+ * Server instance reference for graceful shutdown.
+ */
+let server: ServerType | null = null;
+
+/**
+ * Flag to prevent multiple shutdown attempts.
+ */
+let isShuttingDown = false;
+
+/**
+ * Performs graceful shutdown of the HTTP server.
+ */
+async function shutdown(): Promise<void> {
+  if (isShuttingDown) {
+    return;
+  }
+
+  isShuttingDown = true;
+  console.log('[mock-server] Shutting down...');
+
+  // Set a timeout for force exit
+  const forceExitTimeout = setTimeout(() => {
+    console.error('[mock-server] Shutdown timeout exceeded, forcing exit');
+    process.exit(1);
+  }, 5000);
+
+  try {
+    if (server) {
+      server.close();
+    }
+
+    clearTimeout(forceExitTimeout);
+    console.log('[mock-server] Shutdown complete');
+    process.exit(0);
+  } catch (error) {
+    clearTimeout(forceExitTimeout);
+    console.error('[mock-server] Error during shutdown:', error);
+    process.exit(1);
+  }
+}
+
+/**
+ * Main entry point for the mock server runner.
+ */
+async function main(): Promise<void> {
+  // Read configuration from environment variables
+  const config = readConfig();
+
+  if (config.verbose) {
+    console.log('[mock-server] Starting with configuration:');
+    console.log(`  PORT: ${config.port}`);
+    console.log(`  OPENAPI_SPEC_PATH: ${config.specPath}`);
+    console.log(`  VERBOSE: ${config.verbose}`);
+    if (config.handlersDir) {
+      console.log(`  HANDLERS_DIR: ${config.handlersDir}`);
+    }
+    if (config.seedsDir) {
+      console.log(`  SEEDS_DIR: ${config.seedsDir}`);
+    }
+  }
+
+  // Load and parse OpenAPI specification
+  if (config.verbose) {
+    console.log(`[mock-server] Loading OpenAPI spec from: ${config.specPath}`);
+  }
+
+  const spec = await loadOpenApiSpec(config.specPath);
+  const endpointCount = countEndpoints(spec.paths);
+
+  if (config.verbose) {
+    console.log(
+      `[mock-server] Parsed ${endpointCount} endpoints from spec: ${spec.info.title} v${spec.info.version}`,
+    );
+  }
+
+  // Create Hono app with logging middleware
+  const app = new Hono();
+
+  // Add request logging middleware (before Scalar routes)
+  if (config.verbose) {
+    app.use('*', async (c, next) => {
+      const start = Date.now();
+      const method = c.req.method;
+      const path = c.req.path;
+      const query = c.req.query();
+      const queryString =
+        Object.keys(query).length > 0 ? `?${new URLSearchParams(query).toString()}` : '';
+
+      await next();
+
+      const duration = Date.now() - start;
+      const status = c.res.status;
+      const timestamp = new Date().toISOString();
+
+      console.log(
+        `[mock-server] ${timestamp} ${method} ${path}${queryString} - ${status} (${duration}ms)`,
+      );
+    });
+  }
+
+  // Create Scalar mock server (returns a Hono app with all routes configured)
+  const mockServer = await createMockServer({
+    document: spec,
+  });
+
+  // Mount the mock server routes on our Hono app
+  // We use type assertion because Scalar's Hono instance is compatible
+  app.route('/', mockServer as unknown as Hono);
+
+  // Start HTTP server
+  server = serve({
+    fetch: app.fetch,
+    port: config.port,
+  });
+
+  console.log(`[mock-server] Server listening on http://localhost:${config.port}`);
+
+  // Send ready IPC message to parent process
+  sendIpcMessage({
+    type: 'ready',
+    port: config.port,
+    endpointCount,
+  });
+
+  // Register shutdown handlers
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+
+  // Listen for IPC shutdown message from parent
+  process.on('message', (msg: unknown) => {
+    if (typeof msg === 'object' && msg !== null && 'type' in msg) {
+      const message = msg as OpenApiServerMessage;
+      if (message.type === 'shutdown') {
+        shutdown();
+      }
+    }
+  });
+}
+
+// Handle unhandled promise rejections
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('[mock-server] Unhandled rejection at:', promise, 'reason:', reason);
+
+  sendIpcMessage({
+    type: 'error',
+    message: `Unhandled rejection: ${reason}`,
+    stack: reason instanceof Error ? reason.stack : undefined,
+  });
+
+  process.exit(1);
+});
+
+// Handle uncaught exceptions
+process.on('uncaughtException', (error) => {
+  console.error('[mock-server] Uncaught exception:', error);
+
+  sendIpcMessage({
+    type: 'error',
+    message: error.message,
+    stack: error.stack,
+  });
+
+  process.exit(1);
+});
+
+// Run main function with error handling
+main().catch((error) => {
+  const err = error as Error;
+  console.error('[mock-server] Fatal error:', err.message);
+
+  if (err.stack) {
+    console.error(err.stack);
+  }
+
+  sendIpcMessage({
+    type: 'error',
+    message: err.message,
+    stack: err.stack,
+  });
+
+  process.exit(1);
+});

--- a/packages/vite-plugin-open-api-server/tsdown.config.ts
+++ b/packages/vite-plugin-open-api-server/tsdown.config.ts
@@ -10,7 +10,9 @@
  *
  * ## How
  * - Uses `defineConfig` for type-safe configuration
- * - Single entry point (`src/index.ts`) matching package.json exports
+ * - Two entry points:
+ *   - `src/index.ts`: Main plugin entry matching package.json exports
+ *   - `src/runner/openapi-server-runner.mts`: Standalone mock server executable
  * - ESM-only format matching `"type": "module"` in package.json
  * - Generates `.d.mts` declaration files for TypeScript consumers
  * - Produces source maps for debugging production builds
@@ -22,6 +24,7 @@
  * - **Source maps**: Allows debugging original TypeScript in production
  * - **External deps**: Prevents version conflicts and bundle bloat
  * - **Clean builds**: Removes stale artifacts from previous builds
+ * - **Runner entry**: Separate executable for child process mock server
  *
  * @see https://github.com/nicepkg/tsdown - tsdown documentation
  */
@@ -29,10 +32,12 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   /**
-   * Entry point for the bundle.
-   * Single entry matching package.json exports configuration.
+   * Entry points for the bundle.
+   * - `src/index.ts`: Main plugin entry matching package.json exports
+   * - `src/runner/openapi-server-runner.mts`: Standalone mock server runner
+   *   compiled to `dist/runner/openapi-server-runner.mjs` for child process execution
    */
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/runner/openapi-server-runner.mts'],
 
   /**
    * Output format.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: ^1.19.7
-        version: 1.19.8(hono@4.10.3)
+        version: 1.19.8(hono@4.11.4)
       '@scalar/mock-server':
         specifier: ^0.8.9
         version: 0.8.9(typescript@5.9.3)
@@ -35,6 +35,9 @@ importers:
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
+      hono:
+        specifier: ^4.11.4
+        version: 4.11.4
       yaml:
         specifier: ^2.8.2
         version: 2.8.2
@@ -991,6 +994,10 @@ packages:
     resolution: {integrity: sha512-2LOYWUbnhdxdL8MNbNg9XZig6k+cZXm5IjHn2Aviv7honhBMOHb+jxrKIeJRZJRmn+htUCKhaicxwXuUDlchRA==}
     engines: {node: '>=16.9.0'}
 
+  hono@4.11.4:
+    resolution: {integrity: sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==}
+    engines: {node: '>=16.9.0'}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -1726,9 +1733,9 @@ snapshots:
 
   '@faker-js/faker@9.9.0': {}
 
-  '@hono/node-server@1.19.8(hono@4.10.3)':
+  '@hono/node-server@1.19.8(hono@4.11.4)':
     dependencies:
-      hono: 4.10.3
+      hono: 4.11.4
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2459,6 +2466,8 @@ snapshots:
   highlightjs-curl@1.3.0: {}
 
   hono@4.10.3: {}
+
+  hono@4.11.4: {}
 
   hookable@5.5.3: {}
 


### PR DESCRIPTION
- Create src/runner/openapi-server-runner.mts as standalone ESM entry point
- Read configuration from environment variables (PORT, OPENAPI_SPEC_PATH, VERBOSE)
- Load and parse OpenAPI spec using core parser module
- Create Scalar mock server with document option
- Add conditional request logging middleware for verbose mode
- Start HTTP server with @hono/node-server on configured port
- Send ready IPC message to parent process with port and endpoint count
- Implement graceful shutdown on SIGTERM/SIGINT/IPC messages
- Add comprehensive error handling for uncaught exceptions
- Update tsdown config to build runner as separate entry point
- Add hono dependency and allow console in runner biome config

Closes: vite-open-api-server-6gc.5.8
Closes: vite-open-api-server-6gc.5.5
Closes: vite-open-api-server-6gc.5.2
Closes: vite-open-api-server-6gc.5.10
Closes: vite-open-api-server-6gc.5.7
Closes: vite-open-api-server-6gc.5.4
Closes: vite-open-api-server-6gc.5.1
Closes: vite-open-api-server-6gc.5.9
Closes: vite-open-api-server-6gc.5.6