### PR TITLE
fix(exports): move 'types' condition before 'import' and 'require' in package.json exports

### DIFF
--- a/.changesets/fix-vite-aud-types-condition-order.json
+++ b/.changesets/fix-vite-aud-types-condition-order.json
@@ -1,0 +1,15 @@
+{
+  "branch": "fix/vite-aud-types-condition-order",
+  "bump": "patch",
+  "environments": [
+    "production"
+  ],
+  "packages": [
+    "@websublime/vite-plugin-open-api-core",
+    "@websublime/vite-plugin-open-api-server",
+    "@websublime/vite-plugin-open-api-devtools"
+  ],
+  "changes": [],
+  "created_at": "2026-02-11T09:58:20.411189Z",
+  "updated_at": "2026-02-11T09:58:20.411876Z"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,8 +60,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   }
 }

--- a/packages/devtools-client/package.json
+++ b/packages/devtools-client/package.json
@@ -58,9 +58,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/devtools.d.ts",
       "import": "./dist/devtools.js",
-      "require": "./dist/devtools.umd.cjs",
-      "types": "./dist/devtools.d.ts"
+      "require": "./dist/devtools.umd.cjs"
     },
     "./style.css": "./dist/style.css"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -54,8 +54,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "module": "./dist/index.js"


### PR DESCRIPTION


The 'types' condition in package.json exports maps was placed after 'import' and 'require', making it unreachable. This caused esbuild to emit warnings during devtools-client builds. Fixed in all three packages (core, server, devtools-client) for consistency, following TypeScript's recommendation to always list 'types' first.

Closes: vite-aud

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript type declaration file condition ordering in Vite plugins to ensure accurate type definitions are correctly delivered during production builds.

* **Chores**
  * Updated package export configurations across core, server, and devtools packages to enhance TypeScript type definition support and delivery compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->