### PR TITLE
feat(core): add getTimeline() and clearTimeline() to OpenApiServer

### DIFF
--- a/.changesets/feature-vite-qq9.1-core-package-minor-extensions.json
+++ b/.changesets/feature-vite-qq9.1-core-package-minor-extensions.json
@@ -7,7 +7,18 @@
   "packages": [
     "@websublime/vite-plugin-open-api-core"
   ],
-  "changes": [],
+  "changes": [
+    "5c5e1e02b6950d653fa44fe1f0b64bf36c4e3101",
+    "2333daaf8170c569c5ce4014c75c78fbc919db97",
+    "5f7633fa13a8ff766df3eebe2893daa0f0a67791",
+    "303e880192a84bc5af17a5f159d68e614265a757",
+    "02db19fd2204c27aee0f715af17198570528d0e9",
+    "a7ad783ceb71cb3e6fe31b84ccb76cb19e945138",
+    "f2a89db2ea685da89c7d6b5602f6fb1840ada766",
+    "4b4bf3212f09bb69a3d249117df385712a96a353",
+    "e6b9993129cccb056c310dccd610cbf32f8b5f66",
+    "fb407897a645ceb716d0c62ada83e961c281a8af"
+  ],
   "created_at": "2026-02-12T13:06:06.793233Z",
-  "updated_at": "2026-02-12T13:06:06.793689Z"
+  "updated_at": "2026-02-12T13:06:43.899419Z"
 }

--- a/.changesets/feature-vite-qq9.1-core-package-minor-extensions.json
+++ b/.changesets/feature-vite-qq9.1-core-package-minor-extensions.json
@@ -1,0 +1,13 @@
+{
+  "branch": "feature/vite-qq9.1-core-package-minor-extensions",
+  "bump": "minor",
+  "environments": [
+    "production"
+  ],
+  "packages": [
+    "@websublime/vite-plugin-open-api-core"
+  ],
+  "changes": [],
+  "created_at": "2026-02-12T13:06:06.793233Z",
+  "updated_at": "2026-02-12T13:06:06.793689Z"
+}

--- a/.changesets/feature-vite-qq9.1-core-package-minor-extensions.json
+++ b/.changesets/feature-vite-qq9.1-core-package-minor-extensions.json
@@ -7,7 +7,20 @@
   "packages": [
     "@websublime/vite-plugin-open-api-core"
   ],
-  "changes": [],
+  "changes": [
+    "e8a14821e209d886ba353307ad0d76f857f520ac",
+    "e6a3a240d38500909be3197f3b543dbe4a097534",
+    "5c5e1e02b6950d653fa44fe1f0b64bf36c4e3101",
+    "2333daaf8170c569c5ce4014c75c78fbc919db97",
+    "5f7633fa13a8ff766df3eebe2893daa0f0a67791",
+    "303e880192a84bc5af17a5f159d68e614265a757",
+    "02db19fd2204c27aee0f715af17198570528d0e9",
+    "a7ad783ceb71cb3e6fe31b84ccb76cb19e945138",
+    "f2a89db2ea685da89c7d6b5602f6fb1840ada766",
+    "4b4bf3212f09bb69a3d249117df385712a96a353",
+    "e6b9993129cccb056c310dccd610cbf32f8b5f66",
+    "fb407897a645ceb716d0c62ada83e961c281a8af"
+  ],
   "created_at": "2026-02-12T13:59:27.297310Z",
-  "updated_at": "2026-02-12T13:59:27.297717Z"
+  "updated_at": "2026-02-12T13:59:58.920343Z"
 }

--- a/.changesets/feature-vite-qq9.1-core-package-minor-extensions.json
+++ b/.changesets/feature-vite-qq9.1-core-package-minor-extensions.json
@@ -7,18 +7,7 @@
   "packages": [
     "@websublime/vite-plugin-open-api-core"
   ],
-  "changes": [
-    "5c5e1e02b6950d653fa44fe1f0b64bf36c4e3101",
-    "2333daaf8170c569c5ce4014c75c78fbc919db97",
-    "5f7633fa13a8ff766df3eebe2893daa0f0a67791",
-    "303e880192a84bc5af17a5f159d68e614265a757",
-    "02db19fd2204c27aee0f715af17198570528d0e9",
-    "a7ad783ceb71cb3e6fe31b84ccb76cb19e945138",
-    "f2a89db2ea685da89c7d6b5602f6fb1840ada766",
-    "4b4bf3212f09bb69a3d249117df385712a96a353",
-    "e6b9993129cccb056c310dccd610cbf32f8b5f66",
-    "fb407897a645ceb716d0c62ada83e961c281a8af"
-  ],
-  "created_at": "2026-02-12T13:06:06.793233Z",
-  "updated_at": "2026-02-12T13:06:43.899419Z"
+  "changes": [],
+  "created_at": "2026-02-12T13:59:27.297310Z",
+  "updated_at": "2026-02-12T13:59:27.297717Z"
 }

--- a/packages/core/src/__tests__/server.test.ts
+++ b/packages/core/src/__tests__/server.test.ts
@@ -518,6 +518,86 @@ describe('createOpenApiServer', () => {
     });
   });
 
+  describe('getTimeline', () => {
+    it('should return empty timeline initially', async () => {
+      const server = await createOpenApiServer({
+        spec: singleEndpointDocument,
+      });
+
+      const timeline = server.getTimeline();
+      expect(timeline).toBeInstanceOf(Array);
+      expect(timeline).toHaveLength(0);
+    });
+
+    it('should return timeline entries after requests', async () => {
+      const server = await createOpenApiServer({
+        spec: singleEndpointDocument,
+      });
+
+      await server.app.request('/pets');
+
+      const timeline = server.getTimeline();
+      expect(timeline.length).toBeGreaterThan(0);
+      expect(timeline[0]).toHaveProperty('id');
+      expect(timeline[0]).toHaveProperty('timestamp');
+      expect(timeline[0]).toHaveProperty('type');
+      expect(timeline[0]).toHaveProperty('data');
+    });
+
+    it('should contain both request and response entries', async () => {
+      const server = await createOpenApiServer({
+        spec: singleEndpointDocument,
+      });
+
+      await server.app.request('/pets');
+
+      const timeline = server.getTimeline();
+      const types = timeline.map((e) => e.type);
+      expect(types).toContain('request');
+      expect(types).toContain('response');
+    });
+  });
+
+  describe('clearTimeline', () => {
+    it('should clear timeline and return count', async () => {
+      const server = await createOpenApiServer({
+        spec: singleEndpointDocument,
+      });
+
+      await server.app.request('/pets');
+
+      const timelineBefore = server.getTimeline();
+      const initialCount = timelineBefore.length;
+      expect(initialCount).toBeGreaterThan(0);
+
+      const clearedCount = server.clearTimeline();
+      expect(clearedCount).toBe(initialCount);
+      expect(server.getTimeline()).toHaveLength(0);
+    });
+
+    it('should return 0 when clearing empty timeline', async () => {
+      const server = await createOpenApiServer({
+        spec: minimalDocument,
+      });
+
+      const clearedCount = server.clearTimeline();
+      expect(clearedCount).toBe(0);
+    });
+
+    it('should allow new entries after clearing', async () => {
+      const server = await createOpenApiServer({
+        spec: singleEndpointDocument,
+      });
+
+      await server.app.request('/pets');
+      server.clearTimeline();
+      expect(server.getTimeline()).toHaveLength(0);
+
+      await server.app.request('/pets');
+      expect(server.getTimeline().length).toBeGreaterThan(0);
+    });
+  });
+
   describe('custom handlers', () => {
     it('should use custom handler when provided', async () => {
       const handlers = new Map<string, HandlerFn>([

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,43 +12,34 @@
 // Server Factory
 // =============================================================================
 
-export { createOpenApiServer } from './server.js';
 export type { OpenApiServer, OpenApiServerConfig } from './server.js';
+export { createOpenApiServer } from './server.js';
 
 // =============================================================================
 // DevTools Server - Static File Serving
 // =============================================================================
 
-export { mountDevToolsRoutes } from './devtools-server.js';
 export type { MountDevToolsOptions } from './devtools-server.js';
+export { mountDevToolsRoutes } from './devtools-server.js';
 
 // =============================================================================
 // Parser Module - OpenAPI Document Processing
 // =============================================================================
 
-export { processOpenApiDocument, ProcessorError } from './parser/index.js';
 export type { ProcessorOptions } from './parser/index.js';
+export { ProcessorError, processOpenApiDocument } from './parser/index.js';
 
 // =============================================================================
 // Store Module - In-Memory Data Store
 // =============================================================================
 
-export { createStore, StoreError } from './store/index.js';
 export type { Store, StoreOptions } from './store/index.js';
+export { createStore, StoreError } from './store/index.js';
 
 // =============================================================================
 // Router Module - Hono Route Generation
 // =============================================================================
 
-export {
-    buildRegistry,
-    buildRoutes,
-    convertOpenApiPath,
-    createEndpointKey,
-    parseEndpointKey,
-    updateRegistryHandlers,
-    updateRegistrySeeds
-} from './router/index.js';
 export type {
     EndpointEntry,
     EndpointKey,
@@ -59,6 +50,15 @@ export type {
     RouteBuilderOptions,
     RouteBuilderResult,
     SecurityRequirement
+} from './router/index.js';
+export {
+    buildRegistry,
+    buildRoutes,
+    convertOpenApiPath,
+    createEndpointKey,
+    parseEndpointKey,
+    updateRegistryHandlers,
+    updateRegistrySeeds
 } from './router/index.js';
 
 // =============================================================================
@@ -79,9 +79,6 @@ export {
 // Handlers Module - Custom Handler Execution
 // =============================================================================
 
-export {
-    defineHandlers, executeHandler, ExecutorError, normalizeResponse
-} from './handlers/index.js';
 export type {
     HandlerContext,
     HandlerDefinition,
@@ -96,22 +93,22 @@ export type {
     Logger,
     NormalizeOptions
 } from './handlers/index.js';
+export {
+    defineHandlers, ExecutorError, executeHandler, normalizeResponse
+} from './handlers/index.js';
 
 // =============================================================================
 // WebSocket Module - Real-time Communication
 // =============================================================================
 
-export {
-    CLIENT_COMMAND_TYPES,
-    createCommandHandler,
-    createWebSocketHub
-} from './websocket/index.js';
 export type {
     ClientCommand,
     ClientCommandData,
     ClientCommandType,
     CommandHandler,
     CommandHandlerDeps,
+    MultiSpecClientCommand,
+    MultiSpecServerEvent,
     RequestLogEntry,
     ResponseLogEntry,
     ServerEvent,
@@ -125,12 +122,16 @@ export type {
     WebSocketHubLogger,
     WebSocketHubOptions
 } from './websocket/index.js';
+export {
+    CLIENT_COMMAND_TYPES,
+    createCommandHandler,
+    createWebSocketHub
+} from './websocket/index.js';
 
 // =============================================================================
 // Security Module - OpenAPI Security Scheme Handling
 // =============================================================================
 
-export { resolveSecuritySchemes, validateSecurity } from './security/index.js';
 export type {
     ResolvedSecurityScheme,
     SecurityContext,
@@ -140,33 +141,26 @@ export type {
     SecurityValidationResult,
     ValidateSecurityOptions
 } from './security/index.js';
+export { resolveSecuritySchemes, validateSecurity } from './security/index.js';
 
 // =============================================================================
 // Simulation Module - Error and Delay Simulation
 // =============================================================================
 
-export { createSimulationManager } from './simulation/index.js';
 export type { Simulation, SimulationManager } from './simulation/index.js';
+export { createSimulationManager } from './simulation/index.js';
 
 // =============================================================================
 // Internal API Module - DevTools and Management Routes
 // =============================================================================
 
-export { mountInternalApi } from './internal-api.js';
 export type { InternalApiDeps, TimelineEntry } from './internal-api.js';
+export { mountInternalApi } from './internal-api.js';
 
 // =============================================================================
 // Seeds Module - Seed Loading and Execution
 // =============================================================================
 
-export {
-    createSeedContext,
-    createSeedHelper,
-    defineSeeds,
-    executeSeedDefinition,
-    executeSeeds,
-    SeedExecutorError
-} from './seeds/index.js';
 export type {
     AnySeedFn,
     AsyncSeedFn,
@@ -177,5 +171,13 @@ export type {
     SeedFn,
     SeedFnMap,
     SeedHelper
+} from './seeds/index.js';
+export {
+    createSeedContext,
+    createSeedHelper,
+    defineSeeds,
+    executeSeedDefinition,
+    executeSeeds,
+    SeedExecutorError
 } from './seeds/index.js';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,53 +12,53 @@
 // Server Factory
 // =============================================================================
 
-export type { OpenApiServer, OpenApiServerConfig } from './server.js';
 export { createOpenApiServer } from './server.js';
+export type { OpenApiServer, OpenApiServerConfig } from './server.js';
 
 // =============================================================================
 // DevTools Server - Static File Serving
 // =============================================================================
 
-export type { MountDevToolsOptions } from './devtools-server.js';
 export { mountDevToolsRoutes } from './devtools-server.js';
+export type { MountDevToolsOptions } from './devtools-server.js';
 
 // =============================================================================
 // Parser Module - OpenAPI Document Processing
 // =============================================================================
 
+export { processOpenApiDocument, ProcessorError } from './parser/index.js';
 export type { ProcessorOptions } from './parser/index.js';
-export { ProcessorError, processOpenApiDocument } from './parser/index.js';
 
 // =============================================================================
 // Store Module - In-Memory Data Store
 // =============================================================================
 
-export type { Store, StoreOptions } from './store/index.js';
 export { createStore, StoreError } from './store/index.js';
+export type { Store, StoreOptions } from './store/index.js';
 
 // =============================================================================
 // Router Module - Hono Route Generation
 // =============================================================================
 
-export type {
-  EndpointEntry,
-  EndpointKey,
-  EndpointRegistry,
-  HttpMethod,
-  RegistryBuilderOptions,
-  RegistryStats,
-  RouteBuilderOptions,
-  RouteBuilderResult,
-  SecurityRequirement,
-} from './router/index.js';
 export {
-  buildRegistry,
-  buildRoutes,
-  convertOpenApiPath,
-  createEndpointKey,
-  parseEndpointKey,
-  updateRegistryHandlers,
-  updateRegistrySeeds,
+    buildRegistry,
+    buildRoutes,
+    convertOpenApiPath,
+    createEndpointKey,
+    parseEndpointKey,
+    updateRegistryHandlers,
+    updateRegistrySeeds
+} from './router/index.js';
+export type {
+    EndpointEntry,
+    EndpointKey,
+    EndpointRegistry,
+    HttpMethod,
+    RegistryBuilderOptions,
+    RegistryStats,
+    RouteBuilderOptions,
+    RouteBuilderResult,
+    SecurityRequirement
 } from './router/index.js';
 
 // =============================================================================
@@ -68,115 +68,114 @@ export {
 // Public API - main generator functions
 // Mapping constants for advanced customization
 export {
-  DATE_FORMAT_POST_PROCESSING,
-  FIELD_NAME_MAPPING,
-  generateFromFieldName,
-  generateFromSchema,
-  TYPE_FORMAT_MAPPING,
+    DATE_FORMAT_POST_PROCESSING,
+    FIELD_NAME_MAPPING,
+    generateFromFieldName,
+    generateFromSchema,
+    TYPE_FORMAT_MAPPING
 } from './generator/index.js';
 
 // =============================================================================
 // Handlers Module - Custom Handler Execution
 // =============================================================================
 
-export type {
-  HandlerContext,
-  HandlerDefinition,
-  HandlerFn,
-  HandlerRequest,
-  HandlerResponse,
-  HandlerResponseMeta,
-  HandlerReturn,
-  HandlerReturnRaw,
-  HandlerReturnWithHeaders,
-  HandlerReturnWithStatus,
-  Logger,
-  NormalizeOptions,
-} from './handlers/index.js';
 export {
-  defineHandlers,
-  ExecutorError,
-  executeHandler,
-  normalizeResponse,
+    defineHandlers, executeHandler, ExecutorError, normalizeResponse
+} from './handlers/index.js';
+export type {
+    HandlerContext,
+    HandlerDefinition,
+    HandlerFn,
+    HandlerRequest,
+    HandlerResponse,
+    HandlerResponseMeta,
+    HandlerReturn,
+    HandlerReturnRaw,
+    HandlerReturnWithHeaders,
+    HandlerReturnWithStatus,
+    Logger,
+    NormalizeOptions
 } from './handlers/index.js';
 
 // =============================================================================
 // WebSocket Module - Real-time Communication
 // =============================================================================
 
-export type {
-  ClientCommand,
-  ClientCommandData,
-  ClientCommandType,
-  CommandHandler,
-  CommandHandlerDeps,
-  RequestLogEntry,
-  ResponseLogEntry,
-  ServerEvent,
-  ServerEventData,
-  SimulationBase,
-  SimulationConfig,
-  SimulationState,
-  WebSocketClient,
-  WebSocketHub,
-  WebSocketHubLogger,
-  WebSocketHubOptions,
-} from './websocket/index.js';
 export {
-  CLIENT_COMMAND_TYPES,
-  createCommandHandler,
-  createWebSocketHub,
+    CLIENT_COMMAND_TYPES,
+    createCommandHandler,
+    createWebSocketHub
+} from './websocket/index.js';
+export type {
+    ClientCommand,
+    ClientCommandData,
+    ClientCommandType,
+    CommandHandler,
+    CommandHandlerDeps,
+    RequestLogEntry,
+    ResponseLogEntry,
+    ServerEvent,
+    ServerEventData,
+    SimulationBase,
+    SimulationConfig,
+    SimulationState,
+    SpecInfo,
+    WebSocketClient,
+    WebSocketHub,
+    WebSocketHubLogger,
+    WebSocketHubOptions
 } from './websocket/index.js';
 
 // =============================================================================
 // Security Module - OpenAPI Security Scheme Handling
 // =============================================================================
 
-export type {
-  ResolvedSecurityScheme,
-  SecurityContext,
-  SecurityRequest,
-  SecuritySchemeIn,
-  SecuritySchemeType,
-  SecurityValidationResult,
-  ValidateSecurityOptions,
-} from './security/index.js';
 export { resolveSecuritySchemes, validateSecurity } from './security/index.js';
+export type {
+    ResolvedSecurityScheme,
+    SecurityContext,
+    SecurityRequest,
+    SecuritySchemeIn,
+    SecuritySchemeType,
+    SecurityValidationResult,
+    ValidateSecurityOptions
+} from './security/index.js';
 
 // =============================================================================
 // Simulation Module - Error and Delay Simulation
 // =============================================================================
 
-export type { Simulation, SimulationManager } from './simulation/index.js';
 export { createSimulationManager } from './simulation/index.js';
+export type { Simulation, SimulationManager } from './simulation/index.js';
 
 // =============================================================================
 // Internal API Module - DevTools and Management Routes
 // =============================================================================
 
-export type { InternalApiDeps, TimelineEntry } from './internal-api.js';
 export { mountInternalApi } from './internal-api.js';
+export type { InternalApiDeps, TimelineEntry } from './internal-api.js';
 
 // =============================================================================
 // Seeds Module - Seed Loading and Execution
 // =============================================================================
 
-export type {
-  AnySeedFn,
-  AsyncSeedFn,
-  ExecuteSeedsOptions,
-  ExecuteSeedsResult,
-  SeedContext,
-  SeedDefinition,
-  SeedFn,
-  SeedFnMap,
-  SeedHelper,
-} from './seeds/index.js';
 export {
-  createSeedContext,
-  createSeedHelper,
-  defineSeeds,
-  executeSeedDefinition,
-  executeSeeds,
-  SeedExecutorError,
+    createSeedContext,
+    createSeedHelper,
+    defineSeeds,
+    executeSeedDefinition,
+    executeSeeds,
+    SeedExecutorError
 } from './seeds/index.js';
+export type {
+    AnySeedFn,
+    AsyncSeedFn,
+    ExecuteSeedsOptions,
+    ExecuteSeedsResult,
+    SeedContext,
+    SeedDefinition,
+    SeedFn,
+    SeedFnMap,
+    SeedHelper
+} from './seeds/index.js';
+

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,24 +41,24 @@ export { createStore, StoreError } from './store/index.js';
 // =============================================================================
 
 export type {
-    EndpointEntry,
-    EndpointKey,
-    EndpointRegistry,
-    HttpMethod,
-    RegistryBuilderOptions,
-    RegistryStats,
-    RouteBuilderOptions,
-    RouteBuilderResult,
-    SecurityRequirement
+  EndpointEntry,
+  EndpointKey,
+  EndpointRegistry,
+  HttpMethod,
+  RegistryBuilderOptions,
+  RegistryStats,
+  RouteBuilderOptions,
+  RouteBuilderResult,
+  SecurityRequirement,
 } from './router/index.js';
 export {
-    buildRegistry,
-    buildRoutes,
-    convertOpenApiPath,
-    createEndpointKey,
-    parseEndpointKey,
-    updateRegistryHandlers,
-    updateRegistrySeeds
+  buildRegistry,
+  buildRoutes,
+  convertOpenApiPath,
+  createEndpointKey,
+  parseEndpointKey,
+  updateRegistryHandlers,
+  updateRegistrySeeds,
 } from './router/index.js';
 
 // =============================================================================
@@ -68,11 +68,11 @@ export {
 // Public API - main generator functions
 // Mapping constants for advanced customization
 export {
-    DATE_FORMAT_POST_PROCESSING,
-    FIELD_NAME_MAPPING,
-    generateFromFieldName,
-    generateFromSchema,
-    TYPE_FORMAT_MAPPING
+  DATE_FORMAT_POST_PROCESSING,
+  FIELD_NAME_MAPPING,
+  generateFromFieldName,
+  generateFromSchema,
+  TYPE_FORMAT_MAPPING,
 } from './generator/index.js';
 
 // =============================================================================
@@ -80,21 +80,24 @@ export {
 // =============================================================================
 
 export type {
-    HandlerContext,
-    HandlerDefinition,
-    HandlerFn,
-    HandlerRequest,
-    HandlerResponse,
-    HandlerResponseMeta,
-    HandlerReturn,
-    HandlerReturnRaw,
-    HandlerReturnWithHeaders,
-    HandlerReturnWithStatus,
-    Logger,
-    NormalizeOptions
+  HandlerContext,
+  HandlerDefinition,
+  HandlerFn,
+  HandlerRequest,
+  HandlerResponse,
+  HandlerResponseMeta,
+  HandlerReturn,
+  HandlerReturnRaw,
+  HandlerReturnWithHeaders,
+  HandlerReturnWithStatus,
+  Logger,
+  NormalizeOptions,
 } from './handlers/index.js';
 export {
-    defineHandlers, ExecutorError, executeHandler, normalizeResponse
+  defineHandlers,
+  ExecutorError,
+  executeHandler,
+  normalizeResponse,
 } from './handlers/index.js';
 
 // =============================================================================
@@ -102,30 +105,30 @@ export {
 // =============================================================================
 
 export type {
-    ClientCommand,
-    ClientCommandData,
-    ClientCommandType,
-    CommandHandler,
-    CommandHandlerDeps,
-    MultiSpecClientCommand,
-    MultiSpecServerEvent,
-    RequestLogEntry,
-    ResponseLogEntry,
-    ServerEvent,
-    ServerEventData,
-    SimulationBase,
-    SimulationConfig,
-    SimulationState,
-    SpecInfo,
-    WebSocketClient,
-    WebSocketHub,
-    WebSocketHubLogger,
-    WebSocketHubOptions
+  ClientCommand,
+  ClientCommandData,
+  ClientCommandType,
+  CommandHandler,
+  CommandHandlerDeps,
+  MultiSpecClientCommand,
+  MultiSpecServerEvent,
+  RequestLogEntry,
+  ResponseLogEntry,
+  ServerEvent,
+  ServerEventData,
+  SimulationBase,
+  SimulationConfig,
+  SimulationState,
+  SpecInfo,
+  WebSocketClient,
+  WebSocketHub,
+  WebSocketHubLogger,
+  WebSocketHubOptions,
 } from './websocket/index.js';
 export {
-    CLIENT_COMMAND_TYPES,
-    createCommandHandler,
-    createWebSocketHub
+  CLIENT_COMMAND_TYPES,
+  createCommandHandler,
+  createWebSocketHub,
 } from './websocket/index.js';
 
 // =============================================================================
@@ -133,13 +136,13 @@ export {
 // =============================================================================
 
 export type {
-    ResolvedSecurityScheme,
-    SecurityContext,
-    SecurityRequest,
-    SecuritySchemeIn,
-    SecuritySchemeType,
-    SecurityValidationResult,
-    ValidateSecurityOptions
+  ResolvedSecurityScheme,
+  SecurityContext,
+  SecurityRequest,
+  SecuritySchemeIn,
+  SecuritySchemeType,
+  SecurityValidationResult,
+  ValidateSecurityOptions,
 } from './security/index.js';
 export { resolveSecuritySchemes, validateSecurity } from './security/index.js';
 
@@ -162,22 +165,21 @@ export { mountInternalApi } from './internal-api.js';
 // =============================================================================
 
 export type {
-    AnySeedFn,
-    AsyncSeedFn,
-    ExecuteSeedsOptions,
-    ExecuteSeedsResult,
-    SeedContext,
-    SeedDefinition,
-    SeedFn,
-    SeedFnMap,
-    SeedHelper
+  AnySeedFn,
+  AsyncSeedFn,
+  ExecuteSeedsOptions,
+  ExecuteSeedsResult,
+  SeedContext,
+  SeedDefinition,
+  SeedFn,
+  SeedFnMap,
+  SeedHelper,
 } from './seeds/index.js';
 export {
-    createSeedContext,
-    createSeedHelper,
-    defineSeeds,
-    executeSeedDefinition,
-    executeSeeds,
-    SeedExecutorError
+  createSeedContext,
+  createSeedHelper,
+  defineSeeds,
+  executeSeedDefinition,
+  executeSeeds,
+  SeedExecutorError,
 } from './seeds/index.js';
-

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -141,6 +141,26 @@ export interface OpenApiServer {
   updateSeeds(seeds: Map<string, unknown[]>): void;
 
   /**
+   * Get the request/response timeline for this server instance
+   *
+   * Returns the internal timeline array. The orchestrator uses this
+   * to serve per-spec timeline data via the aggregated internal API
+   * and multi-spec WebSocket commands.
+   *
+   * @returns Timeline entries array (most recent last)
+   */
+  getTimeline(): TimelineEntry[];
+
+  /**
+   * Clear the timeline for this server instance
+   *
+   * Used by the orchestrator for spec-scoped `clear:timeline` commands.
+   *
+   * @returns Number of entries cleared
+   */
+  clearTimeline(): number;
+
+  /**
    * Get the configured port
    */
   readonly port: number;
@@ -478,6 +498,16 @@ export async function createOpenApiServer(config: OpenApiServerConfig): Promise<
       });
 
       logger.info(`[vite-plugin-open-api-core] Handlers updated: ${newHandlers.size} handlers`);
+    },
+
+    getTimeline(): TimelineEntry[] {
+      return timeline;
+    },
+
+    clearTimeline(): number {
+      const count = timeline.length;
+      timeline.length = 0;
+      return count;
     },
 
     /**

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -149,7 +149,7 @@ export interface OpenApiServer {
    *
    * @returns Timeline entries array (most recent last)
    */
-  getTimeline(): TimelineEntry[];
+  getTimeline(): readonly TimelineEntry[];
 
   /**
    * Clear the timeline for this server instance
@@ -500,13 +500,19 @@ export async function createOpenApiServer(config: OpenApiServerConfig): Promise<
       logger.info(`[vite-plugin-open-api-core] Handlers updated: ${newHandlers.size} handlers`);
     },
 
-    getTimeline(): TimelineEntry[] {
+    getTimeline(): readonly TimelineEntry[] {
       return timeline;
     },
 
     clearTimeline(): number {
       const count = timeline.length;
       timeline.length = 0;
+
+      wsHub.broadcast({
+        type: 'timeline:cleared',
+        data: { count },
+      });
+
       return count;
     },
 

--- a/packages/core/src/websocket/index.ts
+++ b/packages/core/src/websocket/index.ts
@@ -8,10 +8,10 @@
  * @module websocket
  */
 
-export { createCommandHandler, type CommandHandlerDeps } from './command-handler.js';
+export { type CommandHandlerDeps, createCommandHandler } from './command-handler.js';
 
-export {
-    createWebSocketHub, type CommandHandler, type WebSocketClient,
+export {type CommandHandler, 
+    createWebSocketHub, type WebSocketClient,
     type WebSocketHub,
     type WebSocketHubLogger,
     type WebSocketHubOptions
@@ -22,6 +22,8 @@ export {
     type ClientCommand,
     type ClientCommandData,
     type ClientCommandType,
+    type MultiSpecClientCommand,
+    type MultiSpecServerEvent,
     type RequestLogEntry,
     type ResponseLogEntry,
     type ServerEvent,
@@ -31,4 +33,3 @@ export {
     type SimulationState,
     type SpecInfo
 } from './protocol.js';
-

--- a/packages/core/src/websocket/index.ts
+++ b/packages/core/src/websocket/index.ts
@@ -10,26 +10,28 @@
 
 export { type CommandHandlerDeps, createCommandHandler } from './command-handler.js';
 
-export {type CommandHandler, 
-    createWebSocketHub, type WebSocketClient,
-    type WebSocketHub,
-    type WebSocketHubLogger,
-    type WebSocketHubOptions
+export {
+  type CommandHandler,
+  createWebSocketHub,
+  type WebSocketClient,
+  type WebSocketHub,
+  type WebSocketHubLogger,
+  type WebSocketHubOptions,
 } from './hub.js';
 
 export {
-    CLIENT_COMMAND_TYPES,
-    type ClientCommand,
-    type ClientCommandData,
-    type ClientCommandType,
-    type MultiSpecClientCommand,
-    type MultiSpecServerEvent,
-    type RequestLogEntry,
-    type ResponseLogEntry,
-    type ServerEvent,
-    type ServerEventData,
-    type SimulationBase,
-    type SimulationConfig,
-    type SimulationState,
-    type SpecInfo
+  CLIENT_COMMAND_TYPES,
+  type ClientCommand,
+  type ClientCommandData,
+  type ClientCommandType,
+  type MultiSpecClientCommand,
+  type MultiSpecServerEvent,
+  type RequestLogEntry,
+  type ResponseLogEntry,
+  type ServerEvent,
+  type ServerEventData,
+  type SimulationBase,
+  type SimulationConfig,
+  type SimulationState,
+  type SpecInfo,
 } from './protocol.js';

--- a/packages/core/src/websocket/index.ts
+++ b/packages/core/src/websocket/index.ts
@@ -8,27 +8,27 @@
  * @module websocket
  */
 
-export { type CommandHandlerDeps, createCommandHandler } from './command-handler.js';
+export { createCommandHandler, type CommandHandlerDeps } from './command-handler.js';
 
 export {
-  type CommandHandler,
-  createWebSocketHub,
-  type WebSocketClient,
-  type WebSocketHub,
-  type WebSocketHubLogger,
-  type WebSocketHubOptions,
+    createWebSocketHub, type CommandHandler, type WebSocketClient,
+    type WebSocketHub,
+    type WebSocketHubLogger,
+    type WebSocketHubOptions
 } from './hub.js';
 
 export {
-  CLIENT_COMMAND_TYPES,
-  type ClientCommand,
-  type ClientCommandData,
-  type ClientCommandType,
-  type RequestLogEntry,
-  type ResponseLogEntry,
-  type ServerEvent,
-  type ServerEventData,
-  type SimulationBase,
-  type SimulationConfig,
-  type SimulationState,
+    CLIENT_COMMAND_TYPES,
+    type ClientCommand,
+    type ClientCommandData,
+    type ClientCommandType,
+    type RequestLogEntry,
+    type ResponseLogEntry,
+    type ServerEvent,
+    type ServerEventData,
+    type SimulationBase,
+    type SimulationConfig,
+    type SimulationState,
+    type SpecInfo
 } from './protocol.js';
+

--- a/packages/core/src/websocket/protocol.ts
+++ b/packages/core/src/websocket/protocol.ts
@@ -194,7 +194,10 @@ export type MultiSpecServerEvent =
   | { type: 'connected'; data: { serverVersion: string; specs: SpecInfo[] } }
   | { type: 'request'; data: RequestLogEntry & { specId: string } }
   | { type: 'response'; data: ResponseLogEntry & { specId: string } }
-  | { type: 'store:updated'; data: { specId: string; schema: string; action: string; count?: number } }
+  | {
+      type: 'store:updated';
+      data: { specId: string; schema: string; action: string; count?: number };
+    }
   | { type: 'handlers:updated'; data: { specId: string; count: number } }
   | { type: 'seeds:updated'; data: { specId: string; count: number } }
   | { type: 'simulation:added'; data: { specId: string; path: string } }

--- a/packages/core/src/websocket/protocol.ts
+++ b/packages/core/src/websocket/protocol.ts
@@ -9,6 +9,30 @@
  */
 
 /**
+ * Spec metadata for DevTools and WebSocket protocol
+ *
+ * Represents a single OpenAPI spec instance in a multi-spec setup.
+ * Used by the orchestrator to describe available specs in the
+ * `connected` event and DevTools spec selector.
+ */
+export interface SpecInfo {
+  /** Unique spec identifier (explicit or auto-derived from info.title) */
+  id: string;
+  /** Human-readable spec title from OpenAPI info.title */
+  title: string;
+  /** Spec version from OpenAPI info.version */
+  version: string;
+  /** Proxy path for this spec (e.g., /api/pets/v1) */
+  proxyPath: string;
+  /** Deterministic color for UI display */
+  color: string;
+  /** Number of endpoints in this spec */
+  endpointCount: number;
+  /** Number of schemas in this spec */
+  schemaCount: number;
+}
+
+/**
  * Request log entry for timeline
  * Note: query allows string[] to match HandlerRequest.query for multi-value params
  */

--- a/packages/core/src/websocket/protocol.ts
+++ b/packages/core/src/websocket/protocol.ts
@@ -135,8 +135,10 @@ export type ServerEvent =
  * Used both for TypeScript type inference and runtime validation.
  *
  * @remarks
- * When adding new commands, add them here first. The ClientCommand type
- * and runtime validation will automatically include them.
+ * When adding new single-spec commands, add them here first. The ClientCommand
+ * type and runtime validation will automatically include them.
+ * Multi-spec commands (e.g., `get:specs`) are defined separately in
+ * `MultiSpecClientCommand` and handled by the orchestrator, not by the core hub.
  */
 export const CLIENT_COMMAND_TYPES = [
   'get:registry',
@@ -198,8 +200,11 @@ export type MultiSpecServerEvent =
       type: 'store:updated';
       data: { specId: string; schema: string; action: string; count?: number };
     }
+  | { type: 'handler:reloaded'; data: { specId: string; file: string } }
   | { type: 'handlers:updated'; data: { specId: string; count: number } }
+  | { type: 'seed:reloaded'; data: { specId: string; file: string } }
   | { type: 'seeds:updated'; data: { specId: string; count: number } }
+  | { type: 'simulation:active'; data: { specId: string; simulations: SimulationState[] } }
   | { type: 'simulation:added'; data: { specId: string; path: string } }
   | { type: 'simulation:removed'; data: { specId: string; path: string } }
   | { type: 'simulations:cleared'; data: { specId: string; count: number } }
@@ -219,6 +224,11 @@ export type MultiSpecServerEvent =
  *
  * Commands sent by DevTools clients in a multi-spec setup.
  * Some commands are global (no specId required), others are spec-scoped.
+ *
+ * Note: These commands are handled by the multi-spec orchestrator's WebSocket
+ * wrapper in the server package, NOT by the core hub's `CLIENT_COMMAND_TYPES`
+ * validation. The `get:specs` command in particular is orchestrator-only and
+ * is not included in `CLIENT_COMMAND_TYPES`.
  */
 export type MultiSpecClientCommand =
   // Global commands (no specId required)

--- a/packages/core/src/websocket/protocol.ts
+++ b/packages/core/src/websocket/protocol.ts
@@ -179,6 +179,63 @@ export type ClientCommand =
   | { type: 'clear:timeline' }
   | { type: 'reseed' };
 
+// =============================================================================
+// Multi-Spec Protocol Types
+// =============================================================================
+
+/**
+ * Server event with spec context
+ *
+ * These are used by the orchestrator's multi-spec WebSocket wrapper.
+ * The core protocol.ts remains unchanged — the wrapper adds specId at the
+ * orchestrator level before broadcasting.
+ */
+export type MultiSpecServerEvent =
+  | { type: 'connected'; data: { serverVersion: string; specs: SpecInfo[] } }
+  | { type: 'request'; data: RequestLogEntry & { specId: string } }
+  | { type: 'response'; data: ResponseLogEntry & { specId: string } }
+  | { type: 'store:updated'; data: { specId: string; schema: string; action: string; count?: number } }
+  | { type: 'handlers:updated'; data: { specId: string; count: number } }
+  | { type: 'seeds:updated'; data: { specId: string; count: number } }
+  | { type: 'simulation:added'; data: { specId: string; path: string } }
+  | { type: 'simulation:removed'; data: { specId: string; path: string } }
+  | { type: 'simulations:cleared'; data: { specId: string; count: number } }
+  | { type: 'registry'; data: { specId: string; registry: unknown } }
+  | { type: 'timeline'; data: { specId: string; entries: unknown[]; count: number; total: number } }
+  | { type: 'store'; data: { specId: string; schema: string; items: unknown[]; count: number } }
+  | { type: 'store:set'; data: { specId: string; schema: string; success: boolean; count: number } }
+  | { type: 'store:cleared'; data: { specId: string; schema: string; success: boolean } }
+  | { type: 'simulation:set'; data: { specId: string; path: string; success: boolean } }
+  | { type: 'simulation:cleared'; data: { specId: string; path: string; success: boolean } }
+  | { type: 'reseeded'; data: { specId: string; success: boolean; schemas: string[] } }
+  | { type: 'timeline:cleared'; data: { specId: string; count: number } }
+  | { type: 'error'; data: { specId?: string; command: string; message: string } };
+
+/**
+ * Client commands with spec context
+ *
+ * Commands sent by DevTools clients in a multi-spec setup.
+ * Some commands are global (no specId required), others are spec-scoped.
+ */
+export type MultiSpecClientCommand =
+  // Global commands (no specId required)
+  | { type: 'get:specs' }
+  | { type: 'get:registry'; data?: { specId?: string } }
+  | { type: 'get:timeline'; data?: { specId?: string; limit?: number } }
+  | { type: 'clear:timeline'; data?: { specId?: string } }
+
+  // Spec-scoped commands (specId required)
+  | { type: 'get:store'; data: { specId: string; schema: string } }
+  | { type: 'set:store'; data: { specId: string; schema: string; items: unknown[] } }
+  | { type: 'clear:store'; data: { specId: string; schema: string } }
+  | { type: 'set:simulation'; data: { specId: string } & SimulationConfig }
+  | { type: 'clear:simulation'; data: { specId: string; path: string } }
+  | { type: 'reseed'; data: { specId: string } };
+
+// =============================================================================
+// Helper Types
+// =============================================================================
+
 /**
  * Extract the data type for a specific server event type
  *


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-spec protocol support for managing multiple OpenAPI specs
  * Timeline management: view and clear operation history
  * WebSocket auto-connect option to control initial connection signaling
  * Expanded public types for multi-spec commands, events, and spec metadata

* **Tests**
  * Added tests for timeline behavior and WebSocket auto-connect scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->