### PR TITLE
feat(devtools): add specs store and useSpecs composable

### DIFF
--- a/packages/devtools-client/src/composables/__tests__/useSpecs.test.ts
+++ b/packages/devtools-client/src/composables/__tests__/useSpecs.test.ts
@@ -1,0 +1,197 @@
+/**
+ * useSpecs Composable Tests
+ *
+ * What: Unit tests for the useSpecs composable
+ * How: Tests utility functions and store delegation
+ * Why: Ensures spec metadata helpers work correctly for component consumers
+ *
+ * @module composables/__tests__/useSpecs.test
+ */
+
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { SpecInfo } from '../../stores/specs';
+import { useSpecsStore } from '../../stores/specs';
+import { useSpecs } from '../useSpecs';
+
+/**
+ * Create a mock SpecInfo entry
+ */
+function createMockSpec(overrides: Partial<SpecInfo> = {}): SpecInfo {
+  return {
+    id: 'petstore',
+    title: 'Petstore API',
+    version: '1.0.0',
+    proxyPath: '/api/petstore',
+    color: '#4ade80',
+    endpointCount: 10,
+    schemaCount: 5,
+    ...overrides,
+  };
+}
+
+describe('useSpecs', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe('store delegation', () => {
+    it('should expose specs from store', () => {
+      const store = useSpecsStore();
+      const specs = [createMockSpec()];
+      store.setSpecs(specs);
+
+      const { specs: composableSpecs } = useSpecs();
+
+      expect(composableSpecs.value).toEqual(specs);
+    });
+
+    it('should expose activeSpecFilter from store', () => {
+      const store = useSpecsStore();
+      store.setFilter('petstore');
+
+      const { activeSpecFilter } = useSpecs();
+
+      expect(activeSpecFilter.value).toBe('petstore');
+    });
+
+    it('should expose specMap from store', () => {
+      const store = useSpecsStore();
+      const spec = createMockSpec({ id: 'petstore' });
+      store.setSpecs([spec]);
+
+      const { specMap } = useSpecs();
+
+      expect(specMap.value.get('petstore')).toEqual(spec);
+    });
+
+    it('should expose specIds from store', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'a' }), createMockSpec({ id: 'b' })]);
+
+      const { specIds } = useSpecs();
+
+      expect(specIds.value).toEqual(['a', 'b']);
+    });
+
+    it('should expose activeSpec from store', () => {
+      const store = useSpecsStore();
+      const spec = createMockSpec({ id: 'petstore' });
+      store.setSpecs([spec]);
+      store.setFilter('petstore');
+
+      const { activeSpec } = useSpecs();
+
+      expect(activeSpec.value).toEqual(spec);
+    });
+
+    it('should expose isFiltered from store', () => {
+      const store = useSpecsStore();
+      store.setFilter('petstore');
+
+      const { isFiltered } = useSpecs();
+
+      expect(isFiltered.value).toBe(true);
+    });
+
+    it('should delegate setSpecs to store', () => {
+      const store = useSpecsStore();
+      const { setSpecs } = useSpecs();
+      const specs = [createMockSpec()];
+
+      setSpecs(specs);
+
+      expect(store.specs).toEqual(specs);
+    });
+
+    it('should delegate setFilter to store', () => {
+      const store = useSpecsStore();
+      const { setFilter } = useSpecs();
+
+      setFilter('petstore');
+
+      expect(store.activeSpecFilter).toBe('petstore');
+    });
+
+    it('should delegate toggleFilter to store', () => {
+      const store = useSpecsStore();
+      const { toggleFilter } = useSpecs();
+
+      toggleFilter('petstore');
+      expect(store.activeSpecFilter).toBe('petstore');
+
+      toggleFilter('petstore');
+      expect(store.activeSpecFilter).toBeNull();
+    });
+  });
+
+  describe('getSpecColor', () => {
+    it('should return the color for a known spec', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore', color: '#4ade80' })]);
+
+      const { getSpecColor } = useSpecs();
+
+      expect(getSpecColor('petstore')).toBe('#4ade80');
+    });
+
+    it('should return fallback color for unknown spec', () => {
+      const { getSpecColor } = useSpecs();
+
+      expect(getSpecColor('nonexistent')).toBe('#94a3b8');
+    });
+  });
+
+  describe('specLabel', () => {
+    it('should format label as "title (version)"', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore', title: 'Petstore API', version: '1.0.0' })]);
+
+      const { specLabel } = useSpecs();
+
+      expect(specLabel('petstore')).toBe('Petstore API (1.0.0)');
+    });
+
+    it('should return spec ID when spec not found', () => {
+      const { specLabel } = useSpecs();
+
+      expect(specLabel('unknown-spec')).toBe('unknown-spec');
+    });
+
+    it('should handle different title and version combinations', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'users', title: 'Users Service', version: '2.3.1' })]);
+
+      const { specLabel } = useSpecs();
+
+      expect(specLabel('users')).toBe('Users Service (2.3.1)');
+    });
+  });
+
+  describe('isActiveSpec', () => {
+    it('should return true when spec is the active filter', () => {
+      const store = useSpecsStore();
+      store.setFilter('petstore');
+
+      const { isActiveSpec } = useSpecs();
+
+      expect(isActiveSpec('petstore')).toBe(true);
+    });
+
+    it('should return false when spec is not the active filter', () => {
+      const store = useSpecsStore();
+      store.setFilter('users');
+
+      const { isActiveSpec } = useSpecs();
+
+      expect(isActiveSpec('petstore')).toBe(false);
+    });
+
+    it('should return false when no filter is active', () => {
+      const { isActiveSpec } = useSpecs();
+
+      expect(isActiveSpec('petstore')).toBe(false);
+    });
+  });
+});

--- a/packages/devtools-client/src/composables/__tests__/useSpecs.test.ts
+++ b/packages/devtools-client/src/composables/__tests__/useSpecs.test.ts
@@ -49,6 +49,7 @@ describe('useSpecs', () => {
 
     it('should expose activeSpecFilter from store', () => {
       const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
       store.setFilter('petstore');
 
       const { activeSpecFilter } = useSpecs();
@@ -88,6 +89,7 @@ describe('useSpecs', () => {
 
     it('should expose isFiltered from store', () => {
       const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
       store.setFilter('petstore');
 
       const { isFiltered } = useSpecs();
@@ -107,6 +109,7 @@ describe('useSpecs', () => {
 
     it('should delegate setFilter to store', () => {
       const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
       const { setFilter } = useSpecs();
 
       setFilter('petstore');
@@ -116,6 +119,7 @@ describe('useSpecs', () => {
 
     it('should delegate toggleFilter to store', () => {
       const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
       const { toggleFilter } = useSpecs();
 
       toggleFilter('petstore');
@@ -172,6 +176,7 @@ describe('useSpecs', () => {
   describe('isActiveSpec', () => {
     it('should return true when spec is the active filter', () => {
       const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
       store.setFilter('petstore');
 
       const { isActiveSpec } = useSpecs();
@@ -181,6 +186,10 @@ describe('useSpecs', () => {
 
     it('should return false when spec is not the active filter', () => {
       const store = useSpecsStore();
+      store.setSpecs([
+        createMockSpec({ id: 'petstore' }),
+        createMockSpec({ id: 'users', title: 'Users API' }),
+      ]);
       store.setFilter('users');
 
       const { isActiveSpec } = useSpecs();

--- a/packages/devtools-client/src/composables/index.ts
+++ b/packages/devtools-client/src/composables/index.ts
@@ -11,6 +11,7 @@
  * - useWebSocket: Handles WebSocket connection with auto-reconnect
  */
 
+export type { SpecInfo } from './useSpecs';
 export { useSpecs } from './useSpecs';
 export type { ThemeMode } from './useTheme';
 export { useTheme } from './useTheme';

--- a/packages/devtools-client/src/composables/index.ts
+++ b/packages/devtools-client/src/composables/index.ts
@@ -7,9 +7,11 @@
  *
  * Composable responsibilities:
  * - useTheme: Manages dark/light mode theme switching
+ * - useSpecs: Provides spec metadata utilities (colors, labels, filtering)
  * - useWebSocket: Handles WebSocket connection with auto-reconnect
  */
 
+export { useSpecs } from './useSpecs';
 export type { ThemeMode } from './useTheme';
 export { useTheme } from './useTheme';
 export type {

--- a/packages/devtools-client/src/composables/useSpecs.ts
+++ b/packages/devtools-client/src/composables/useSpecs.ts
@@ -1,0 +1,96 @@
+/**
+ * useSpecs Composable
+ *
+ * What: Convenience wrapper around the specs Pinia store
+ * How: Re-exports store state/computed and adds utility helpers for components
+ * Why: Provides a clean API for components that need spec metadata (colors, labels, filter state)
+ *
+ * @module composables/useSpecs
+ */
+
+import { computed } from 'vue';
+
+import { type SpecInfo, useSpecsStore } from '../stores/specs';
+
+/**
+ * useSpecs composable
+ *
+ * Provides spec metadata utilities for components including:
+ * - Direct access to store state and computed
+ * - Color lookup by spec ID
+ * - Label formatting (title + version)
+ * - Active spec checking
+ *
+ * @returns Spec metadata utilities
+ */
+export function useSpecs() {
+  const store = useSpecsStore();
+
+  /**
+   * Get the assigned color for a spec ID, with fallback
+   */
+  function getSpecColor(specId: string): string {
+    return store.getColor(specId);
+  }
+
+  /**
+   * Format a spec label as "title (version)" for display
+   * Returns the spec ID if the spec is not found
+   */
+  function specLabel(specId: string): string {
+    const spec = store.specMap.get(specId);
+    if (!spec) return specId;
+    return `${spec.title} (${spec.version})`;
+  }
+
+  /**
+   * Check whether a given spec is the currently active filter
+   */
+  function isActiveSpec(specId: string): boolean {
+    return store.activeSpecFilter === specId;
+  }
+
+  return {
+    // Store state (readonly via computed)
+    /** All registered specs */
+    specs: computed(() => store.specs),
+
+    /** Currently active spec filter ID (null = all) */
+    activeSpecFilter: computed(() => store.activeSpecFilter),
+
+    // Store computed
+    /** Map of spec ID to SpecInfo */
+    specMap: computed(() => store.specMap),
+
+    /** Ordered list of spec IDs */
+    specIds: computed(() => store.specIds),
+
+    /** The currently filtered spec, or null */
+    activeSpec: computed(() => store.activeSpec),
+
+    /** Whether a spec filter is currently active */
+    isFiltered: computed(() => store.isFiltered),
+
+    // Store actions
+    /** Replace the full specs list */
+    setSpecs: store.setSpecs,
+
+    /** Set the active spec filter */
+    setFilter: store.setFilter,
+
+    /** Toggle the active spec filter */
+    toggleFilter: store.toggleFilter,
+
+    // Utility helpers
+    /** Get the color for a spec ID */
+    getSpecColor,
+
+    /** Format spec label as "title (version)" */
+    specLabel,
+
+    /** Check if a spec is the active filter */
+    isActiveSpec,
+  };
+}
+
+export type { SpecInfo };

--- a/packages/devtools-client/src/stores/__tests__/specs.test.ts
+++ b/packages/devtools-client/src/stores/__tests__/specs.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Specs Store Tests
+ *
+ * What: Unit tests for the specs Pinia store
+ * How: Tests state management, computed properties, and actions
+ * Why: Ensures reliable multi-spec metadata management for DevTools UI
+ *
+ * @module stores/__tests__/specs.test
+ */
+
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { type SpecInfo, useSpecsStore } from '../specs';
+
+/**
+ * Create a mock SpecInfo entry
+ */
+function createMockSpec(overrides: Partial<SpecInfo> = {}): SpecInfo {
+  return {
+    id: 'petstore',
+    title: 'Petstore API',
+    version: '1.0.0',
+    proxyPath: '/api/petstore',
+    color: '#4ade80',
+    endpointCount: 10,
+    schemaCount: 5,
+    ...overrides,
+  };
+}
+
+describe('useSpecsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe('initial state', () => {
+    it('should have empty specs array', () => {
+      const store = useSpecsStore();
+      expect(store.specs).toEqual([]);
+    });
+
+    it('should have null activeSpecFilter', () => {
+      const store = useSpecsStore();
+      expect(store.activeSpecFilter).toBeNull();
+    });
+
+    it('should have empty specMap', () => {
+      const store = useSpecsStore();
+      expect(store.specMap.size).toBe(0);
+    });
+
+    it('should have empty specIds', () => {
+      const store = useSpecsStore();
+      expect(store.specIds).toEqual([]);
+    });
+
+    it('should have null activeSpec', () => {
+      const store = useSpecsStore();
+      expect(store.activeSpec).toBeNull();
+    });
+
+    it('should not be filtered', () => {
+      const store = useSpecsStore();
+      expect(store.isFiltered).toBe(false);
+    });
+  });
+
+  describe('setSpecs', () => {
+    it('should set specs from array', () => {
+      const store = useSpecsStore();
+      const spec = createMockSpec();
+
+      store.setSpecs([spec]);
+
+      expect(store.specs).toHaveLength(1);
+      expect(store.specs[0]).toEqual(spec);
+    });
+
+    it('should replace existing specs', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'first' })]);
+      store.setSpecs([createMockSpec({ id: 'second' })]);
+
+      expect(store.specs).toHaveLength(1);
+      expect(store.specs[0].id).toBe('second');
+    });
+
+    it('should handle empty array', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec()]);
+      store.setSpecs([]);
+
+      expect(store.specs).toEqual([]);
+    });
+
+    it('should handle multiple specs', () => {
+      const store = useSpecsStore();
+      const specs = [
+        createMockSpec({ id: 'petstore', title: 'Petstore' }),
+        createMockSpec({ id: 'users', title: 'Users API', color: '#60a5fa' }),
+      ];
+
+      store.setSpecs(specs);
+
+      expect(store.specs).toHaveLength(2);
+    });
+  });
+
+  describe('specMap computed', () => {
+    it('should create a map keyed by spec id', () => {
+      const store = useSpecsStore();
+      const spec = createMockSpec({ id: 'petstore' });
+      store.setSpecs([spec]);
+
+      expect(store.specMap.get('petstore')).toEqual(spec);
+    });
+
+    it('should update when specs change', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'first' })]);
+
+      expect(store.specMap.has('first')).toBe(true);
+
+      store.setSpecs([createMockSpec({ id: 'second' })]);
+
+      expect(store.specMap.has('first')).toBe(false);
+      expect(store.specMap.has('second')).toBe(true);
+    });
+
+    it('should handle multiple specs in map', () => {
+      const store = useSpecsStore();
+      store.setSpecs([
+        createMockSpec({ id: 'a' }),
+        createMockSpec({ id: 'b' }),
+        createMockSpec({ id: 'c' }),
+      ]);
+
+      expect(store.specMap.size).toBe(3);
+    });
+  });
+
+  describe('specIds computed', () => {
+    it('should return ordered list of spec IDs', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' }), createMockSpec({ id: 'users' })]);
+
+      expect(store.specIds).toEqual(['petstore', 'users']);
+    });
+
+    it('should preserve insertion order', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'z-api' }), createMockSpec({ id: 'a-api' })]);
+
+      expect(store.specIds).toEqual(['z-api', 'a-api']);
+    });
+  });
+
+  describe('setFilter', () => {
+    it('should set active spec filter', () => {
+      const store = useSpecsStore();
+      store.setFilter('petstore');
+
+      expect(store.activeSpecFilter).toBe('petstore');
+    });
+
+    it('should clear filter when set to null', () => {
+      const store = useSpecsStore();
+      store.setFilter('petstore');
+      store.setFilter(null);
+
+      expect(store.activeSpecFilter).toBeNull();
+    });
+  });
+
+  describe('toggleFilter', () => {
+    it('should activate filter for a spec', () => {
+      const store = useSpecsStore();
+      store.toggleFilter('petstore');
+
+      expect(store.activeSpecFilter).toBe('petstore');
+    });
+
+    it('should deactivate filter when toggling same spec', () => {
+      const store = useSpecsStore();
+      store.toggleFilter('petstore');
+      store.toggleFilter('petstore');
+
+      expect(store.activeSpecFilter).toBeNull();
+    });
+
+    it('should switch filter when toggling different spec', () => {
+      const store = useSpecsStore();
+      store.toggleFilter('petstore');
+      store.toggleFilter('users');
+
+      expect(store.activeSpecFilter).toBe('users');
+    });
+  });
+
+  describe('activeSpec computed', () => {
+    it('should return null when no filter is active', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
+
+      expect(store.activeSpec).toBeNull();
+    });
+
+    it('should return the filtered spec', () => {
+      const store = useSpecsStore();
+      const spec = createMockSpec({ id: 'petstore' });
+      store.setSpecs([spec]);
+      store.setFilter('petstore');
+
+      expect(store.activeSpec).toEqual(spec);
+    });
+
+    it('should return null when filter references nonexistent spec', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
+      store.setFilter('nonexistent');
+
+      expect(store.activeSpec).toBeNull();
+    });
+  });
+
+  describe('isFiltered computed', () => {
+    it('should be false when no filter is active', () => {
+      const store = useSpecsStore();
+      expect(store.isFiltered).toBe(false);
+    });
+
+    it('should be true when a filter is active', () => {
+      const store = useSpecsStore();
+      store.setFilter('petstore');
+      expect(store.isFiltered).toBe(true);
+    });
+
+    it('should return to false when filter is cleared', () => {
+      const store = useSpecsStore();
+      store.setFilter('petstore');
+      store.setFilter(null);
+      expect(store.isFiltered).toBe(false);
+    });
+  });
+
+  describe('getColor', () => {
+    it('should return the color for a known spec', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore', color: '#4ade80' })]);
+
+      expect(store.getColor('petstore')).toBe('#4ade80');
+    });
+
+    it('should return fallback color for unknown spec', () => {
+      const store = useSpecsStore();
+
+      expect(store.getColor('nonexistent')).toBe('#94a3b8');
+    });
+
+    it('should return correct color for each spec', () => {
+      const store = useSpecsStore();
+      store.setSpecs([
+        createMockSpec({ id: 'petstore', color: '#4ade80' }),
+        createMockSpec({ id: 'users', color: '#60a5fa' }),
+      ]);
+
+      expect(store.getColor('petstore')).toBe('#4ade80');
+      expect(store.getColor('users')).toBe('#60a5fa');
+    });
+  });
+});

--- a/packages/devtools-client/src/stores/__tests__/specs.test.ts
+++ b/packages/devtools-client/src/stores/__tests__/specs.test.ts
@@ -159,6 +159,7 @@ describe('useSpecsStore', () => {
   describe('setFilter', () => {
     it('should set active spec filter', () => {
       const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
       store.setFilter('petstore');
 
       expect(store.activeSpecFilter).toBe('petstore');
@@ -166,8 +167,17 @@ describe('useSpecsStore', () => {
 
     it('should clear filter when set to null', () => {
       const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
       store.setFilter('petstore');
       store.setFilter(null);
+
+      expect(store.activeSpecFilter).toBeNull();
+    });
+
+    it('should reject nonexistent spec ID', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
+      store.setFilter('nonexistent');
 
       expect(store.activeSpecFilter).toBeNull();
     });
@@ -176,6 +186,7 @@ describe('useSpecsStore', () => {
   describe('toggleFilter', () => {
     it('should activate filter for a spec', () => {
       const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
       store.toggleFilter('petstore');
 
       expect(store.activeSpecFilter).toBe('petstore');
@@ -183,6 +194,7 @@ describe('useSpecsStore', () => {
 
     it('should deactivate filter when toggling same spec', () => {
       const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
       store.toggleFilter('petstore');
       store.toggleFilter('petstore');
 
@@ -191,10 +203,22 @@ describe('useSpecsStore', () => {
 
     it('should switch filter when toggling different spec', () => {
       const store = useSpecsStore();
+      store.setSpecs([
+        createMockSpec({ id: 'petstore' }),
+        createMockSpec({ id: 'users', title: 'Users API' }),
+      ]);
       store.toggleFilter('petstore');
       store.toggleFilter('users');
 
       expect(store.activeSpecFilter).toBe('users');
+    });
+
+    it('should reject nonexistent spec ID', () => {
+      const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
+      store.toggleFilter('nonexistent');
+
+      expect(store.activeSpecFilter).toBeNull();
     });
   });
 
@@ -220,7 +244,9 @@ describe('useSpecsStore', () => {
       store.setSpecs([createMockSpec({ id: 'petstore' })]);
       store.setFilter('nonexistent');
 
+      // setFilter rejects nonexistent IDs, so activeSpec is null
       expect(store.activeSpec).toBeNull();
+      expect(store.activeSpecFilter).toBeNull();
     });
   });
 
@@ -232,12 +258,14 @@ describe('useSpecsStore', () => {
 
     it('should be true when a filter is active', () => {
       const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
       store.setFilter('petstore');
       expect(store.isFiltered).toBe(true);
     });
 
     it('should return to false when filter is cleared', () => {
       const store = useSpecsStore();
+      store.setSpecs([createMockSpec({ id: 'petstore' })]);
       store.setFilter('petstore');
       store.setFilter(null);
       expect(store.isFiltered).toBe(false);

--- a/packages/devtools-client/src/stores/index.ts
+++ b/packages/devtools-client/src/stores/index.ts
@@ -7,6 +7,7 @@
  *
  * Store responsibilities:
  * - registry: Manages endpoint registry data from the server
+ * - specs: Manages multi-spec metadata, filtering, and colors
  * - timeline: Tracks request/response timeline events
  * - models: Manages store data for viewing/editing mock data
  * - simulation: Controls active error simulations
@@ -32,6 +33,9 @@ export type {
 } from './simulation';
 // Simulation store - manages error and delay simulations
 export { SIMULATION_PRESETS, useSimulationStore } from './simulation';
+export type { SpecInfo } from './specs';
+// Specs store - manages multi-spec metadata and filtering
+export { useSpecsStore } from './specs';
 export type {
   HttpMethod as TimelineHttpMethod,
   RequestLogEntry,

--- a/packages/devtools-client/src/stores/specs.ts
+++ b/packages/devtools-client/src/stores/specs.ts
@@ -93,13 +93,18 @@ export const useSpecsStore = defineStore('specs', () => {
    */
   function setSpecs(newSpecs: SpecInfo[]): void {
     specs.value = newSpecs;
+    // Clear stale filter if the active spec no longer exists
+    if (activeSpecFilter.value && !newSpecs.some((s) => s.id === activeSpecFilter.value)) {
+      activeSpecFilter.value = null;
+    }
   }
 
   /**
    * Set the active spec filter by ID, or null to show all
    */
   function setFilter(specId: string | null): void {
-    activeSpecFilter.value = specId;
+    activeSpecFilter.value =
+      specId !== null && !specs.value.some((s) => s.id === specId) ? null : specId;
   }
 
   /**
@@ -107,7 +112,11 @@ export const useSpecsStore = defineStore('specs', () => {
    * otherwise set it as the active filter
    */
   function toggleFilter(specId: string): void {
-    activeSpecFilter.value = activeSpecFilter.value === specId ? null : specId;
+    if (activeSpecFilter.value === specId) {
+      activeSpecFilter.value = null;
+    } else {
+      setFilter(specId);
+    }
   }
 
   /**

--- a/packages/devtools-client/src/stores/specs.ts
+++ b/packages/devtools-client/src/stores/specs.ts
@@ -1,0 +1,141 @@
+/**
+ * Specs Store
+ *
+ * What: Pinia store for managing OpenAPI spec metadata
+ * How: Stores spec info received via WebSocket, provides filtering by active spec
+ * Why: Enables multi-spec awareness across the DevTools UI (colors, labels, filtering)
+ *
+ * @module stores/specs
+ */
+
+import { defineStore } from 'pinia';
+import { computed, ref } from 'vue';
+
+/**
+ * OpenAPI spec metadata
+ *
+ * Canonical source of truth: packages/core/src/websocket/protocol.ts (SpecInfo)
+ * This interface is duplicated here to keep devtools-client decoupled from core.
+ * If the core SpecInfo changes, this must be updated to match.
+ */
+export interface SpecInfo {
+  /** Unique spec identifier */
+  id: string;
+  /** Human-readable title from the OpenAPI info object */
+  title: string;
+  /** Spec version from the OpenAPI info object */
+  version: string;
+  /** Proxy path prefix for this spec's endpoints */
+  proxyPath: string;
+  /** Assigned color for UI differentiation (hex) */
+  color: string;
+  /** Number of endpoints in this spec */
+  endpointCount: number;
+  /** Number of schemas in this spec */
+  schemaCount: number;
+}
+
+/** Default fallback color when a spec has no assigned color (slate-400) */
+const DEFAULT_SPEC_COLOR = '#94a3b8';
+
+/**
+ * Specs store for multi-spec metadata management
+ *
+ * Provides:
+ * - Spec list storage and lookup
+ * - Active spec filtering (null = show all)
+ * - Color retrieval with fallback
+ * - Computed helpers for spec IDs, map, and filter state
+ */
+export const useSpecsStore = defineStore('specs', () => {
+  // ==========================================================================
+  // State
+  // ==========================================================================
+
+  /** All registered specs from the server */
+  const specs = ref<SpecInfo[]>([]);
+
+  /** Currently active spec filter (null = all specs visible) */
+  const activeSpecFilter = ref<string | null>(null);
+
+  // ==========================================================================
+  // Getters / Computed
+  // ==========================================================================
+
+  /**
+   * Map of spec ID to SpecInfo for O(1) lookup
+   */
+  const specMap = computed(() => new Map(specs.value.map((s) => [s.id, s])));
+
+  /**
+   * Ordered list of spec IDs
+   */
+  const specIds = computed(() => specs.value.map((s) => s.id));
+
+  /**
+   * The currently filtered spec, or null if no filter is active
+   */
+  const activeSpec = computed(() =>
+    activeSpecFilter.value ? (specMap.value.get(activeSpecFilter.value) ?? null) : null,
+  );
+
+  /**
+   * Whether a spec filter is currently active
+   */
+  const isFiltered = computed(() => activeSpecFilter.value !== null);
+
+  // ==========================================================================
+  // Actions
+  // ==========================================================================
+
+  /**
+   * Replace the full specs list (typically from a WebSocket connected event)
+   */
+  function setSpecs(newSpecs: SpecInfo[]): void {
+    specs.value = newSpecs;
+  }
+
+  /**
+   * Set the active spec filter by ID, or null to show all
+   */
+  function setFilter(specId: string | null): void {
+    activeSpecFilter.value = specId;
+  }
+
+  /**
+   * Toggle the active spec filter: if the given spec is already active, clear;
+   * otherwise set it as the active filter
+   */
+  function toggleFilter(specId: string): void {
+    activeSpecFilter.value = activeSpecFilter.value === specId ? null : specId;
+  }
+
+  /**
+   * Get the assigned color for a spec, with fallback to default slate color
+   */
+  function getColor(specId: string): string {
+    return specMap.value.get(specId)?.color ?? DEFAULT_SPEC_COLOR;
+  }
+
+  // ==========================================================================
+  // Return
+  // ==========================================================================
+
+  return {
+    // State
+    specs,
+    activeSpecFilter,
+
+    // Getters
+    specMap,
+    specIds,
+    activeSpec,
+    isFiltered,
+
+    // Actions
+    setSpecs,
+    setFilter,
+    toggleFilter,
+    getColor,
+  };
+});


### PR DESCRIPTION
Implement multi-spec metadata management for the DevTools UI:

- Specs Pinia store (stores/specs.ts): state (specs, activeSpecFilter), computed (specMap, specIds, activeSpec, isFiltered), actions (setSpecs, setFilter, toggleFilter, getColor with '#94a3b8' fallback)
- useSpecs composable (composables/useSpecs.ts): thin convenience wrapper with getSpecColor, specLabel, isActiveSpec helpers
- SpecInfo interface defined locally to keep devtools-client decoupled from core package, with sync comment noting canonical source
- 29 store tests + 17 composable tests, all passing
- Updated stores/index.ts and composables/index.ts exports

Ref: BEAD vite-open-api-server-d6w.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-spec management with filtering, active-spec selection, and consistent color assignment for specs.
  * Unified composable API for components to access spec lists, maps, IDs, labels, and color helpers.

* **Tests**
  * Comprehensive unit tests covering store behavior, composable mappings, filtering/toggling, label formatting, and color fallback logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->