### PR TITLE
feat(devtools): add multi-spec support to useWebSocket composable

### DIFF
--- a/.changesets/feature-vite-open-api-server-d6w.3-websocket-composable.json
+++ b/.changesets/feature-vite-open-api-server-d6w.3-websocket-composable.json
@@ -1,0 +1,16 @@
+{
+  "branch": "feature/vite-open-api-server-d6w.3-websocket-composable",
+  "bump": "patch",
+  "environments": [
+    "staging"
+  ],
+  "packages": [
+    "@websublime/vite-plugin-open-api-core",
+    "@websublime/vite-plugin-open-api-devtools",
+    "petstore-app",
+    "@websublime/vite-plugin-open-api-server"
+  ],
+  "changes": [],
+  "created_at": "2026-03-09T16:53:05.379422Z",
+  "updated_at": "2026-03-09T16:53:05.381638Z"
+}

--- a/packages/devtools-client/src/composables/__tests__/useWebSocket.test.ts
+++ b/packages/devtools-client/src/composables/__tests__/useWebSocket.test.ts
@@ -8,8 +8,10 @@
  * @vitest-environment jsdom
  */
 
+import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useSpecsStore } from '../../stores/specs';
 import { type ClientCommand, type ServerEvent, useWebSocket } from '../useWebSocket';
 
 /**
@@ -108,10 +110,28 @@ class MockWebSocket {
 // Store original WebSocket
 const originalWebSocket = global.WebSocket;
 
+/**
+ * Helper: create mock SpecInfo objects for testing
+ */
+function createMockSpecs(count = 2) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `spec-${i + 1}`,
+    title: `Spec ${i + 1}`,
+    version: `1.${i}.0`,
+    proxyPath: `/api/spec${i + 1}`,
+    color: `#${String(i + 1).padStart(6, '0')}`,
+    endpointCount: 10 + i,
+    schemaCount: 5 + i,
+  }));
+}
+
 describe('useWebSocket', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     MockWebSocket.clearInstances();
+
+    // Set up Pinia so that useSpecsStore() works inside handleMessage
+    setActivePinia(createPinia());
 
     // Replace global WebSocket with MockWebSocket class
     global.WebSocket = MockWebSocket as unknown as typeof WebSocket;
@@ -886,6 +906,405 @@ describe('useWebSocket', () => {
 
       expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
+    });
+  });
+
+  // ===========================================================================
+  // Multi-spec features
+  // ===========================================================================
+
+  describe('multi-spec: connected event populates specs store', () => {
+    it('should call setSpecs when connected event contains specs', async () => {
+      const { connect } = useWebSocket({ autoConnect: false });
+      const specsStore = useSpecsStore();
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      const specs = createMockSpecs(2);
+      MockWebSocket.instances[0].simulateMessage({
+        type: 'connected',
+        data: { serverVersion: '2.0.0', specs },
+      });
+
+      expect(specsStore.specs).toEqual(specs);
+      expect(specsStore.specIds).toEqual(['spec-1', 'spec-2']);
+    });
+
+    it('should not call setSpecs when connected event has no specs', async () => {
+      const { connect } = useWebSocket({ autoConnect: false });
+      const specsStore = useSpecsStore();
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      // Single-spec server: no specs field
+      MockWebSocket.instances[0].simulateMessage({
+        type: 'connected',
+        data: { serverVersion: '1.0.0' },
+      });
+
+      expect(specsStore.specs).toEqual([]);
+    });
+
+    it('should handle empty specs array gracefully', async () => {
+      const { connect } = useWebSocket({ autoConnect: false });
+      const specsStore = useSpecsStore();
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      MockWebSocket.instances[0].simulateMessage({
+        type: 'connected',
+        data: { serverVersion: '2.0.0', specs: [] },
+      });
+
+      expect(specsStore.specs).toEqual([]);
+    });
+
+    it('should update specs store on reconnect with new specs', async () => {
+      const { connect } = useWebSocket({ autoConnect: false });
+      const specsStore = useSpecsStore();
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      // Initial connect with 2 specs
+      const specs1 = createMockSpecs(2);
+      MockWebSocket.instances[0].simulateMessage({
+        type: 'connected',
+        data: { serverVersion: '2.0.0', specs: specs1 },
+      });
+      expect(specsStore.specs).toHaveLength(2);
+
+      // Simulate reconnect with 3 specs (e.g., spec added)
+      const specs2 = createMockSpecs(3);
+      MockWebSocket.instances[0].simulateMessage({
+        type: 'connected',
+        data: { serverVersion: '2.0.0', specs: specs2 },
+      });
+      expect(specsStore.specs).toHaveLength(3);
+    });
+  });
+
+  describe('multi-spec: initial data requested on connect', () => {
+    it('should send get:registry and get:timeline for each spec on connect', async () => {
+      const { connect } = useWebSocket({ autoConnect: false });
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      const specs = createMockSpecs(2);
+      MockWebSocket.instances[0].simulateMessage({
+        type: 'connected',
+        data: { serverVersion: '2.0.0', specs },
+      });
+
+      const sentMessages = MockWebSocket.instances[0].sentMessages.map((m) => JSON.parse(m));
+
+      // Should have sent 4 messages: get:registry + get:timeline for each of 2 specs
+      expect(sentMessages).toHaveLength(4);
+      expect(sentMessages).toContainEqual({ type: 'get:registry', data: { specId: 'spec-1' } });
+      expect(sentMessages).toContainEqual({ type: 'get:timeline', data: { specId: 'spec-1' } });
+      expect(sentMessages).toContainEqual({ type: 'get:registry', data: { specId: 'spec-2' } });
+      expect(sentMessages).toContainEqual({ type: 'get:timeline', data: { specId: 'spec-2' } });
+    });
+
+    it('should not send initial data requests when no specs', async () => {
+      const { connect } = useWebSocket({ autoConnect: false });
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      // Single-spec mode: no specs field
+      MockWebSocket.instances[0].simulateMessage({
+        type: 'connected',
+        data: { serverVersion: '1.0.0' },
+      });
+
+      expect(MockWebSocket.instances[0].sentMessages).toHaveLength(0);
+    });
+
+    it('should not send initial data requests when specs array is empty', async () => {
+      const { connect } = useWebSocket({ autoConnect: false });
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      MockWebSocket.instances[0].simulateMessage({
+        type: 'connected',
+        data: { serverVersion: '2.0.0', specs: [] },
+      });
+
+      // Empty specs array: setSpecs still called but no requests sent
+      expect(MockWebSocket.instances[0].sentMessages).toHaveLength(0);
+    });
+  });
+
+  describe('multi-spec: command wrappers', () => {
+    it('getSpecs should send get:specs command', async () => {
+      const { connect, getSpecs } = useWebSocket({ autoConnect: false });
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      const result = getSpecs();
+
+      expect(result).toBe(true);
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[0])).toEqual({
+        type: 'get:specs',
+      });
+    });
+
+    it('getRegistry should send with optional specId', async () => {
+      const { connect, getRegistry } = useWebSocket({ autoConnect: false });
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      // Without specId
+      getRegistry();
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[0])).toEqual({
+        type: 'get:registry',
+      });
+
+      // With specId
+      getRegistry('spec-1');
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[1])).toEqual({
+        type: 'get:registry',
+        data: { specId: 'spec-1' },
+      });
+    });
+
+    it('getTimeline should send with optional specId and limit', async () => {
+      const { connect, getTimeline } = useWebSocket({ autoConnect: false });
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      // Without params
+      getTimeline();
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[0])).toEqual({
+        type: 'get:timeline',
+      });
+
+      // With specId only
+      getTimeline('spec-1');
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[1])).toEqual({
+        type: 'get:timeline',
+        data: { specId: 'spec-1' },
+      });
+
+      // With specId and limit
+      getTimeline('spec-1', 50);
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[2])).toEqual({
+        type: 'get:timeline',
+        data: { specId: 'spec-1', limit: 50 },
+      });
+    });
+
+    it('clearTimeline should send with optional specId', async () => {
+      const { connect, clearTimeline } = useWebSocket({ autoConnect: false });
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      clearTimeline();
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[0])).toEqual({
+        type: 'clear:timeline',
+      });
+
+      clearTimeline('spec-1');
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[1])).toEqual({
+        type: 'clear:timeline',
+        data: { specId: 'spec-1' },
+      });
+    });
+
+    it('getStore should send with required specId and schema', async () => {
+      const { connect, getStore } = useWebSocket({ autoConnect: false });
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      getStore('spec-1', 'Pet');
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[0])).toEqual({
+        type: 'get:store',
+        data: { specId: 'spec-1', schema: 'Pet' },
+      });
+    });
+
+    it('setStore should send with specId, schema, and items', async () => {
+      const { connect, setStore } = useWebSocket({ autoConnect: false });
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      const items = [{ id: 1, name: 'Fluffy' }];
+      setStore('spec-1', 'Pet', items);
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[0])).toEqual({
+        type: 'set:store',
+        data: { specId: 'spec-1', schema: 'Pet', items },
+      });
+    });
+
+    it('clearStore should send with specId and schema', async () => {
+      const { connect, clearStore } = useWebSocket({ autoConnect: false });
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      clearStore('spec-1', 'Pet');
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[0])).toEqual({
+        type: 'clear:store',
+        data: { specId: 'spec-1', schema: 'Pet' },
+      });
+    });
+
+    it('setSimulation should send with specId and config spread', async () => {
+      const { connect, setSimulation } = useWebSocket({ autoConnect: false });
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      setSimulation('spec-1', {
+        path: '/api/pets',
+        method: 'GET',
+        status: 500,
+        delay: 1000,
+      });
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[0])).toEqual({
+        type: 'set:simulation',
+        data: { specId: 'spec-1', path: '/api/pets', method: 'GET', status: 500, delay: 1000 },
+      });
+    });
+
+    it('clearSimulation should send with specId and path', async () => {
+      const { connect, clearSimulation } = useWebSocket({ autoConnect: false });
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      clearSimulation('spec-1', '/api/pets');
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[0])).toEqual({
+        type: 'clear:simulation',
+        data: { specId: 'spec-1', path: '/api/pets' },
+      });
+    });
+
+    it('reseed should send with specId', async () => {
+      const { connect, reseed } = useWebSocket({ autoConnect: false });
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      reseed('spec-1');
+      expect(JSON.parse(MockWebSocket.instances[0].sentMessages[0])).toEqual({
+        type: 'reseed',
+        data: { specId: 'spec-1' },
+      });
+    });
+
+    it('command wrappers should return false when not connected', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { getSpecs, getRegistry, getTimeline, getStore, reseed } = useWebSocket({
+        autoConnect: false,
+      });
+
+      expect(getSpecs()).toBe(false);
+      expect(getRegistry('spec-1')).toBe(false);
+      expect(getTimeline('spec-1')).toBe(false);
+      expect(getStore('spec-1', 'Pet')).toBe(false);
+      expect(reseed('spec-1')).toBe(false);
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('multi-spec: specId in event data', () => {
+    it('should pass specId through to event handlers', async () => {
+      const { connect, on } = useWebSocket({ autoConnect: false });
+      const handler = vi.fn();
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      on('registry', handler);
+
+      MockWebSocket.instances[0].simulateMessage({
+        type: 'registry',
+        data: { specId: 'spec-1', registry: { endpoints: [] } },
+      });
+
+      expect(handler).toHaveBeenCalledWith({
+        specId: 'spec-1',
+        registry: { endpoints: [] },
+      });
+    });
+
+    it('should pass specId in store:updated events', async () => {
+      const { connect, on } = useWebSocket({ autoConnect: false });
+      const handler = vi.fn();
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      on('store:updated', handler);
+
+      MockWebSocket.instances[0].simulateMessage({
+        type: 'store:updated',
+        data: { specId: 'spec-2', schema: 'Pet', action: 'create', count: 5 },
+      });
+
+      expect(handler).toHaveBeenCalledWith({
+        specId: 'spec-2',
+        schema: 'Pet',
+        action: 'create',
+        count: 5,
+      });
+    });
+
+    it('should pass specId in timeline events', async () => {
+      const { connect, on } = useWebSocket({ autoConnect: false });
+      const handler = vi.fn();
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      on('timeline', handler);
+
+      MockWebSocket.instances[0].simulateMessage({
+        type: 'timeline',
+        data: { specId: 'spec-1', entries: [{ id: 'req-1' }], count: 1, total: 10 },
+      });
+
+      expect(handler).toHaveBeenCalledWith({
+        specId: 'spec-1',
+        entries: [{ id: 'req-1' }],
+        count: 1,
+        total: 10,
+      });
+    });
+
+    it('should pass specId in error events', async () => {
+      const { connect, on } = useWebSocket({ autoConnect: false });
+      const handler = vi.fn();
+
+      connect();
+      await vi.runAllTimersAsync();
+
+      on('error', handler);
+
+      MockWebSocket.instances[0].simulateMessage({
+        type: 'error',
+        data: { specId: 'spec-1', command: 'get:store', message: 'Schema not found' },
+      });
+
+      expect(handler).toHaveBeenCalledWith({
+        specId: 'spec-1',
+        command: 'get:store',
+        message: 'Schema not found',
+      });
     });
   });
 });

--- a/packages/devtools-client/src/composables/useWebSocket.ts
+++ b/packages/devtools-client/src/composables/useWebSocket.ts
@@ -11,6 +11,9 @@
 import type { ComputedRef } from 'vue';
 import { computed, getCurrentInstance, onMounted, ref } from 'vue';
 
+import type { SpecInfo } from '../stores/specs';
+import { useSpecsStore } from '../stores/specs';
+
 /**
  * Server event types that can be received from the server
  * These match the ServerEvent types defined in @websublime/vite-plugin-open-api-core
@@ -49,15 +52,21 @@ export interface ServerEvent<T = unknown> {
 
 /**
  * Connected event data
+ *
+ * In multi-spec mode, the server sends `specs` alongside `serverVersion`.
+ * The `specs` field is optional for backward compatibility with single-spec servers.
  */
 export interface ConnectedEventData {
   serverVersion: string;
+  /** Spec metadata array (multi-spec mode only) */
+  specs?: SpecInfo[];
 }
 
 /**
  * Client command types that can be sent to the server
  */
 export type ClientCommandType =
+  | 'get:specs'
   | 'get:registry'
   | 'get:timeline'
   | 'get:store'
@@ -70,10 +79,29 @@ export type ClientCommandType =
 
 /**
  * Client command structure
+ *
+ * In multi-spec mode, commands include `specId` in their data to target
+ * a specific spec instance. Some commands (get:specs, get:registry, get:timeline,
+ * clear:timeline) are global and do not require specId.
  */
 export interface ClientCommand<T = unknown> {
   type: ClientCommandType;
   data?: T;
+}
+
+/**
+ * Simulation configuration for set:simulation command
+ *
+ * Mirrors SimulationConfig from @websublime/vite-plugin-open-api-core.
+ * Kept decoupled to avoid cross-package imports.
+ */
+export interface SimulationConfig {
+  path: string;
+  method?: string;
+  status?: number;
+  delay?: number;
+  body?: unknown;
+  headers?: Record<string, string>;
 }
 
 /**
@@ -152,6 +180,31 @@ export interface UseWebSocketReturn {
   ) => () => void;
   /** Reset the composable state (useful for testing) */
   resetState: () => void;
+
+  // =========================================================================
+  // Multi-spec command wrappers
+  // =========================================================================
+
+  /** Request the list of available specs */
+  getSpecs: () => boolean;
+  /** Request the route registry, optionally scoped to a spec */
+  getRegistry: (specId?: string) => boolean;
+  /** Request timeline entries, optionally scoped to a spec */
+  getTimeline: (specId?: string, limit?: number) => boolean;
+  /** Clear timeline entries, optionally scoped to a spec */
+  clearTimeline: (specId?: string) => boolean;
+  /** Request store data for a specific schema in a spec */
+  getStore: (specId: string, schema: string) => boolean;
+  /** Set store data for a specific schema in a spec */
+  setStore: (specId: string, schema: string, items: unknown[]) => boolean;
+  /** Clear store data for a specific schema in a spec */
+  clearStore: (specId: string, schema: string) => boolean;
+  /** Set a simulation configuration for a spec */
+  setSimulation: (specId: string, config: SimulationConfig) => boolean;
+  /** Clear a simulation for a specific path in a spec */
+  clearSimulation: (specId: string, path: string) => boolean;
+  /** Re-seed mock data for a spec */
+  reseed: (specId: string) => boolean;
 }
 
 /**
@@ -267,19 +320,46 @@ function handleOpen(): void {
 }
 
 /**
+ * Request initial data for each known spec after connection.
+ *
+ * Sends `get:registry` and `get:timeline` for every spec so the UI is
+ * immediately populated without user interaction.
+ */
+function requestInitialData(specs: SpecInfo[]): void {
+  for (const spec of specs) {
+    send({ type: 'get:registry', data: { specId: spec.id } });
+    send({ type: 'get:timeline', data: { specId: spec.id } });
+  }
+}
+
+/**
  * Handle WebSocket message event
  */
 function handleMessage(event: MessageEvent): void {
   try {
     const message = JSON.parse(event.data) as ServerEvent;
 
-    // Handle connected event specially to extract server version
+    // Handle connected event specially to extract server version and specs
     if (message.type === 'connected') {
       const connectedData = message.data as ConnectedEventData;
       serverVersion.value = connectedData.serverVersion;
 
+      // Populate specs store if specs are present (multi-spec mode)
+      if (connectedData.specs && Array.isArray(connectedData.specs)) {
+        // Lazy access to Pinia store — only called when a message arrives,
+        // so Pinia is guaranteed to be installed by then.
+        const specsStore = useSpecsStore();
+        specsStore.setSpecs(connectedData.specs);
+
+        // Request initial data per-spec so the UI is immediately populated
+        requestInitialData(connectedData.specs);
+      }
+
       if (import.meta.env.DEV) {
-        console.log(`[DevTools WebSocket] Server version: ${connectedData.serverVersion}`);
+        const specCount = connectedData.specs?.length ?? 0;
+        console.log(
+          `[DevTools WebSocket] Server version: ${connectedData.serverVersion}, specs: ${specCount}`,
+        );
       }
     }
 
@@ -421,6 +501,90 @@ function send<T = unknown>(command: ClientCommand<T>): boolean {
   }
 }
 
+// =============================================================================
+// Multi-spec command wrappers
+// =============================================================================
+
+/**
+ * Request the list of available specs (global command, no specId)
+ */
+function getSpecs(): boolean {
+  return send({ type: 'get:specs' });
+}
+
+/**
+ * Request the route registry, optionally scoped to a single spec
+ */
+function getRegistry(specId?: string): boolean {
+  return send({ type: 'get:registry', data: specId ? { specId } : undefined });
+}
+
+/**
+ * Request timeline entries, optionally scoped to a single spec
+ */
+function getTimeline(specId?: string, limit?: number): boolean {
+  const data: { specId?: string; limit?: number } = {};
+  if (specId) data.specId = specId;
+  if (limit !== undefined) data.limit = limit;
+  return send({
+    type: 'get:timeline',
+    data: Object.keys(data).length > 0 ? data : undefined,
+  });
+}
+
+/**
+ * Clear timeline entries, optionally scoped to a single spec
+ */
+function clearTimeline(specId?: string): boolean {
+  return send({ type: 'clear:timeline', data: specId ? { specId } : undefined });
+}
+
+/**
+ * Request store data for a specific schema within a spec (spec-scoped)
+ */
+function getStore(specId: string, schema: string): boolean {
+  return send({ type: 'get:store', data: { specId, schema } });
+}
+
+/**
+ * Set store data for a specific schema within a spec (spec-scoped)
+ */
+function setStore(specId: string, schema: string, items: unknown[]): boolean {
+  return send({ type: 'set:store', data: { specId, schema, items } });
+}
+
+/**
+ * Clear store data for a specific schema within a spec (spec-scoped)
+ */
+function clearStore(specId: string, schema: string): boolean {
+  return send({ type: 'clear:store', data: { specId, schema } });
+}
+
+/**
+ * Set a simulation configuration for a spec (spec-scoped)
+ */
+function setSimulation(specId: string, config: SimulationConfig): boolean {
+  return send({ type: 'set:simulation', data: { specId, ...config } });
+}
+
+/**
+ * Clear a simulation for a specific path in a spec (spec-scoped)
+ */
+function clearSimulation(specId: string, path: string): boolean {
+  return send({ type: 'clear:simulation', data: { specId, path } });
+}
+
+/**
+ * Re-seed mock data for a spec (spec-scoped)
+ */
+function reseed(specId: string): boolean {
+  return send({ type: 'reseed', data: { specId } });
+}
+
+// =============================================================================
+// Event subscription
+// =============================================================================
+
 /**
  * Subscribe to a server event
  *
@@ -544,6 +708,7 @@ function resetState(): void {
  * - Auto-reconnect with configurable delay
  * - Event subscription system
  * - Command sending
+ * - Multi-spec command wrappers
  *
  * @param options - Configuration options
  * @returns WebSocket management utilities
@@ -644,5 +809,20 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
      * Reset the composable state (useful for testing)
      */
     resetState,
+
+    // =========================================================================
+    // Multi-spec command wrappers
+    // =========================================================================
+
+    getSpecs,
+    getRegistry,
+    getTimeline,
+    clearTimeline,
+    getStore,
+    setStore,
+    clearStore,
+    setSimulation,
+    clearSimulation,
+    reseed,
   };
 }


### PR DESCRIPTION
- Update ConnectedEventData to include optional specs array
- Add 'get:specs' to ClientCommandType union
- Add SimulationConfig interface for set:simulation commands
- Populate specs store from connected event (lazy Pinia access)
- Request initial get:registry and get:timeline per-spec on connect
- Add 10 typed command wrappers: getSpecs, getRegistry, getTimeline, clearTimeline, getStore, setStore, clearStore, setSimulation, clearSimulation, reseed — all accepting specId parameter
- Extend UseWebSocketReturn interface with new command wrappers
- Add Pinia setup (setActivePinia) to test beforeEach
- Add 22 new tests covering: specs store population, initial data requests, all command wrappers, specId passthrough in events

Ref: vite-open-api-server-d6w.3